### PR TITLE
Installation MCP en 1 commande — install.sh + CLAUDE.md + section MCP dans le README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# LGM GTM Skills — Claude setup
+
+You are looking at the **GTM System repo** maintained by [La Growth Machine](https://lagrowthmachine.com). It bundles a library of public Claude skills (sourcing, list building, campaigns, copywriting, analytics) and an MCP server that lets Claude act directly inside the user's LGM workspace.
+
+## First-time setup
+
+Check if the LGM MCP is already configured by running `claude mcp list` (look for a line starting with `LaGrowthMachine:`). The installer registers the MCP via `claude mcp add --scope user --transport http`, which stores the config in `~/.claude.json` at user scope (available in every project) — not in `settings.json` directly. If the `claude` CLI isn't available, ask the user whether they've already run `sh install.sh`.
+
+**If it is NOT configured**, proactively tell the user:
+
+> "I can see this is the LGM GTM Skills repo. Would you like me to install the LGM MCP and skills? It takes ~1 minute — I'll run `sh install.sh` for you. The installer is interactive: it'll ask whether you have an LGM account and prompt for your API key (hidden) to wire the MCP."
+
+If they say yes, run `sh install.sh` and confirm when done.
+
+**If it IS configured**, present the onboarding to the user:
+
+1. Confirm MCP is connected and list the available MCP tools grouped by category (Audiences, Campaigns, Conversations & leads, Workspace).
+2. List the available GTM Skills grouped by category.
+3. Show the suggested first-steps table.
+4. Ask: *"What would you like to do?"*
+
+---
+
+## What LGM gives you
+
+Once the MCP is connected and skills are installed, two layers work together.
+
+---
+
+### Layer 1 — LGM MCP (Claude acts inside La Growth Machine)
+
+The MCP gives Claude direct access to the user's LGM workspace. No copy-paste, no tab switching.
+
+**Audiences**
+- `create_audience_from_linkedin_url` — create an audience directly from a Sales Navigator search URL
+- `get_audience` — fetch an existing audience by ID
+- `get_audience_leads` — list all leads in an audience
+
+**Campaigns**
+- `list_campaigns` — list all campaigns in the workspace
+- `get_campaign_messages` — fetch the message sequence of a campaign
+- `get_campaign_stats` — get open rates, reply rates, and performance data
+
+**Conversations & leads**
+- `get_lead_conversations` — fetch all conversations for a specific lead
+- `get_conversation_messages` — read the full message thread of a conversation
+- `get_lead_logs` — get the activity log for a lead (visits, clicks, replies)
+
+**Workspace**
+- `list_identities` — list all identities (LinkedIn accounts, email accounts) in the workspace
+- `save_identity_preference` — set a preferred identity for outreach
+
+Tools are exposed under the namespace `mcp__LaGrowthMachine__*`.
+
+---
+
+### Layer 2 — GTM Skills (published in this repo)
+
+Skills guide Claude through complex GTM workflows. Just describe what you want. Skills are categorized into 4 outcomes mirroring the GTM motion:
+
+**Fuel my pipeline** — sourcing, list building, ICP
+
+- `sales-nav-search-builder` — turn a natural-language ICP into a precise LinkedIn Sales Navigator search URL, ready to import as an LGM audience
+- `won-deal-icp-finder` — audit your biggest closed-won deals to find your proven ICP and a look-alike target list
+
+**Get qualified meetings** — campaigns, copywriting, sequences
+
+- `multichannel-campaign-builder` — generate a complete LinkedIn + email sequence from a natural-language brief
+- `campaign-challenger` — benchmark a campaign copy against your existing campaigns and return prioritized fixes before launch
+- `campaign-impact-analyzer` — rank campaigns by real revenue impact by cross-referencing LGM campaigns with HubSpot deals
+
+**Catch opportunities** — reply handling, intent detection — *coming soon*
+
+**Secure my channels** — channel health, deliverability, identities — *coming soon*
+
+---
+
+## Suggested first steps
+
+Suggest one of these depending on what the user wants to do:
+
+| They want to… | Suggest |
+|---|---|
+| Build a prospect list | Use `sales-nav-search-builder` |
+| Find their proven ICP from deals | Use `won-deal-icp-finder` |
+| Write a campaign from scratch | Use `multichannel-campaign-builder` |
+| Pressure-test a campaign before launch | Use `campaign-challenger` |
+| See which campaigns drive pipeline | Use `campaign-impact-analyzer` |
+| Pull live campaign data | Call the MCP directly (e.g. `list_campaigns`, `get_campaign_stats`) |
+
+---
+
+## Tone
+
+Be direct and outcome-focused. LGM users are GTM and growth professionals — they want pipeline results, not feature explanations. Lead with what they can accomplish, not how the tools work.

--- a/README.md
+++ b/README.md
@@ -41,25 +41,58 @@ Channel health, deliverability, identities — protecting the outbound engine.
 
 ---
 
-## Install
+## Install everything in one command
 
-**Prerequisites:** [Claude Code](https://claude.com/product/claude-code), [Cursor](https://cursor.sh), [Codex](https://github.com/openai/codex), [Amp](https://ampcode.com), or any other supported agent.
+The fastest way: install all the GTM skills **and** the LGM MCP server (so Claude can act inside your La Growth Machine workspace) in one go.
 
-**One-line (recommended)** — uses [`skills`](https://github.com/vercel-labs/skills) from Vercel Labs to install the skill into Claude Code (and Cursor, Codex, Amp, +30 other agents) in one command:
+```bash
+curl -fsSL https://raw.githubusercontent.com/LaGrowthMachine/gtm-system/main/install.sh | sh
+```
+
+This installs:
+
+- **The GTM skills** — for Claude Code, Cursor, and Codex (via the [Vercel Labs `skills`](https://github.com/vercel-labs/skills) CLI under the hood)
+- **The LGM MCP** — registered with Claude Code via `claude mcp add --scope user --transport http` (user scope → config stored in `~/.claude.json`, available in every project). The installer is **interactive**: it asks if you have an LGM account, then prompts for your API key (hidden input). If you don't have an account, it shows a quick pitch + register link and skips the MCP setup without touching your Claude config.
+
+The script is idempotent — re-running it is safe. Want to review before running?
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/LaGrowthMachine/gtm-system/main/install.sh -o lgm-install.sh
+less lgm-install.sh
+sh lgm-install.sh
+```
+
+**Prerequisites:** [Claude Code](https://claude.com/product/claude-code) (or [Cursor](https://cursor.sh), [Codex](https://github.com/openai/codex), [Amp](https://ampcode.com), any other supported agent) and Node.js ≥ 18.
+
+---
+
+## Other ways to install
+
+### Install one skill at a time
+
+If you only need a specific skill (no MCP), use the [Vercel Labs `skills`](https://github.com/vercel-labs/skills) CLI directly:
 
 ```bash
 npx skills add LaGrowthMachine/gtm-system/skills/fuel-my-pipeline/sales-nav-search-builder
 ```
 
-Replace the path with any skill from the catalog above. Add `-g` for a global install.
+Replace the path with any skill from the catalog above. Add `-g` for a global install. Works with Claude Code, Cursor, Codex, Amp + 30 other agents.
 
-**Manual install** — if you'd rather not use the CLI, clone and copy:
+### Manual install
+
+Clone the repo and copy the skill folder yourself:
 
 ```bash
 git clone https://github.com/LaGrowthMachine/gtm-system.git
 cd gtm-system
 cp -r skills/fuel-my-pipeline/sales-nav-search-builder ~/.claude/skills/
 ```
+
+### LGM MCP on Claude.ai (web)
+
+Claude.ai accepts HTTP MCP connectors natively. Add the LGM MCP manually:
+
+> Settings → Connectors → Add custom connector → `https://mcpapp.lagrowthmachine.com/mcp`
 
 Then ask Claude — e.g. *"Build me a Sales Navigator search for RevOps leaders in EMEA SaaS."*
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env sh
+#
+# La Growth Machine — GTM Skills + MCP bootstrap installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/LaGrowthMachine/gtm-system/main/install.sh | sh
+#
+# Or, for the security-conscious — review before running:
+#   curl -fsSL https://raw.githubusercontent.com/LaGrowthMachine/gtm-system/main/install.sh -o lgm-install.sh
+#   less lgm-install.sh
+#   sh lgm-install.sh
+#
+# What it does (in order):
+#   1. Checks Node.js / npx are available.
+#   2. Installs LGM GTM Skills via `npx skills add` (claude-code, cursor, codex).
+#   3. Checks the user has an LGM account + collects their API key.
+#      If no account → pitches LGM with a register link and exits cleanly.
+#   4. Registers the LGM MCP in Claude Code via `claude mcp add --scope user
+#      --transport http`, passing the API key as `Authorization: Bearer …`.
+#   5. Prints suggested first-step prompts and a soft "star the repo" nudge.
+#
+# Honors:
+#   LGM_INSTALL_NO_CLAUDE_PERMS=1  — skip the Claude MCP setup entirely.
+#   LGM_INSTALL_NO_LAUNCH=1        — skip the final launch message.
+#   LGM_API_KEY=...                — provide the LGM API key non-interactively.
+#   LGM_INSTALL_VERBOSE=1          — show the full output of npx / claude commands
+#                                    (instead of silencing it) — useful for debugging.
+
+set -eu
+
+SCRIPT_VERSION="2026.06.02.1"
+MCP_URL="https://mcpapp.lagrowthmachine.com/mcp"
+MCP_ALIAS="LaGrowthMachine"
+SKILLS_PKG="LaGrowthMachine/gtm-system"
+
+# UTM-tagged URLs — `utm_source=github` matches the repo README convention,
+# `utm_medium=installer` distinguishes this entry point from the README, and
+# `utm_content` identifies the specific link the user clicked.
+REGISTER_URL="https://app.lagrowthmachine.com/register/?utm_source=github&utm_medium=installer&utm_campaign=gtm-system-installer&utm_content=register"
+API_KEY_URL="https://app.lagrowthmachine.com/settings/integrations/api?utm_source=github&utm_medium=installer&utm_campaign=gtm-system-installer&utm_content=api-key"
+REPO_URL="https://github.com/LaGrowthMachine/gtm-system"
+
+# ─────────────────────────────────────────────────────────────────────
+# Output helpers
+# ─────────────────────────────────────────────────────────────────────
+if [ -t 1 ]; then
+  RESET="\033[0m"
+  GREEN="\033[32m"
+  CYAN="\033[36m"
+  YELLOW="\033[33m"
+  RED="\033[31m"
+  GREY="\033[90m"
+else
+  RESET=""; GREEN=""; CYAN=""; YELLOW=""; RED=""; GREY=""
+fi
+
+say()  { printf "%b\n" "$*"; }
+warn() { printf "%b\n" "${YELLOW}$*${RESET}" >&2; }
+fail() { printf "%b\n" "${RED}$*${RESET}" >&2; exit 1; }
+
+# Run a command, silencing its output unless LGM_INSTALL_VERBOSE=1.
+# Keeps the happy path clean while leaving a debug escape hatch for support.
+#
+# stdin is redirected from /dev/null so the command can't consume the script
+# itself when this installer is piped (curl ... | sh) — otherwise npx would
+# swallow the rest of the script and the MCP step would never run. Interactive
+# prompts read from /dev/tty directly, so they are unaffected.
+run_quiet() {
+  if [ "${LGM_INSTALL_VERBOSE:-0}" = "1" ]; then
+    "$@" </dev/null
+  else
+    "$@" </dev/null >/dev/null 2>&1
+  fi
+}
+
+print_logo() {
+  if [ -t 1 ]; then
+    say "${CYAN}"
+    say "  ██╗      ██████╗ ███╗   ███╗"
+    say "  ██║     ██╔════╝ ████╗ ████║"
+    say "  ██║     ██║  ███╗██╔████╔██║"
+    say "  ██║     ██║   ██║██║╚██╔╝██║"
+    say "  ███████╗╚██████╔╝██║ ╚═╝ ██║"
+    say "  ╚══════╝ ╚═════╝ ╚═╝     ╚═╝"
+    say "${RESET}"
+    say "${GREY}  GTM Skills + MCP installer ${SCRIPT_VERSION}${RESET}"
+    say ""
+  fi
+}
+
+# Tracks whether MCP config got written (controls the final hints)
+LGM_MCP_CONFIGURED=0
+# Tracks the user's API key for Step 4 — collected in Step 3
+LGM_API_KEY_VALUE=""
+
+# Read input from /dev/tty when stdin is a pipe (curl | sh case).
+read_tty() {
+  REPLY=""
+  if [ -r /dev/tty ]; then
+    IFS= read -r REPLY </dev/tty || true
+  else
+    IFS= read -r REPLY || true
+  fi
+  printf "%s" "$REPLY"
+}
+
+# Read a secret silently (no echo) when possible.
+read_secret_tty() {
+  REPLY=""
+  if [ -r /dev/tty ]; then
+    if command -v stty >/dev/null 2>&1; then
+      OLD_STTY="$(stty -g </dev/tty 2>/dev/null || true)"
+      # If the user hits Ctrl+C while echo is off, restore it before exiting —
+      # otherwise their terminal stays invisible (no echo) until they run `reset`.
+      trap 'stty echo </dev/tty 2>/dev/null; printf "\n" >&2; exit 130' INT TERM
+      stty -echo </dev/tty 2>/dev/null || true
+      IFS= read -r REPLY </dev/tty || true
+      [ -n "$OLD_STTY" ] && stty "$OLD_STTY" </dev/tty 2>/dev/null || true
+      trap - INT TERM
+      printf "\n" >&2
+    else
+      IFS= read -r REPLY </dev/tty || true
+    fi
+  else
+    IFS= read -r REPLY || true
+  fi
+  printf "%s" "$REPLY"
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 1 — check Node.js / npx
+# ─────────────────────────────────────────────────────────────────────
+ensure_node() {
+  command -v node >/dev/null 2>&1 || fail "Node.js is required. Install from https://nodejs.org/ and re-run."
+  command -v npx  >/dev/null 2>&1 || fail "npx is required (ships with Node.js ≥ 5.2). Re-install Node from https://nodejs.org/."
+  say "${GREEN}✓ Node.js $(node -v) detected.${RESET}"
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 2 — install GTM Skills (claude-code, cursor, codex)
+# ─────────────────────────────────────────────────────────────────────
+install_skills() {
+  say "${GREY}  Installing LGM GTM Skills for claude-code, cursor, codex...${RESET}"
+  if run_quiet npx --yes skills add "$SKILLS_PKG" \
+       --agents claude-code cursor codex \
+       --global --yes; then
+    say "${GREEN}✓ LGM GTM Skills installed.${RESET}"
+  else
+    warn "  Skill install failed. Run manually:"
+    warn "    npx skills add ${SKILLS_PKG} --agents claude-code cursor codex --global --yes"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Pitch shown to users who don't have an LGM account yet.
+# Returns 0 — execution continues to the final summary; MCP config is skipped.
+# ─────────────────────────────────────────────────────────────────────
+pitch_lgm() {
+  say ""
+  say "${CYAN}La Growth Machine — what the MCP unlocks${RESET}"
+  say "  ${GREEN}•${RESET} Run multichannel outbound (LinkedIn, email, voice, calls) from one workspace"
+  say "  ${GREEN}•${RESET} Pull live campaign data, replies and pipeline straight into Claude"
+  say "  ${GREEN}•${RESET} Push Sales Navigator audiences into LGM with one prompt"
+  say "  ${GREEN}•${RESET} Native HubSpot integration — every deal mapped back to the campaign that won it"
+  say ""
+  say "  ${CYAN}Create your free LGM account (14-day trial):${RESET}"
+  say "  ${CYAN}${REGISTER_URL}${RESET}"
+  say ""
+  say "  ${GREY}Once you have an account, re-run this installer and paste your API key${RESET}"
+  say "  ${GREY}from ${API_KEY_URL%%\?*} to finish the setup.${RESET}"
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 3 — check LGM account + collect the API key
+#
+# The LGM MCP authenticates with a Bearer token (the user's LGM API key)
+# passed on every upstream call. No OAuth dance, no browser step.
+#
+# Behavior:
+#   - LGM_INSTALL_NO_CLAUDE_PERMS=1   → skip everything, no prompt.
+#   - LGM_API_KEY env var present     → non-interactive, use it directly.
+#   - LGM MCP already configured      → skip (idempotent, checked via `claude mcp list`).
+#   - Otherwise interactive:
+#       "Do you have an LGM account?" yes → ask for API key.
+#                                    no  → pitch LGM + register link, exit step.
+# ─────────────────────────────────────────────────────────────────────
+collect_account_and_key() {
+  [ "${LGM_INSTALL_NO_CLAUDE_PERMS:-0}" = "1" ] && return 0
+
+  # Idempotence: skip if our alias is already registered with Claude Code.
+  if command -v claude >/dev/null 2>&1; then
+    if claude mcp list </dev/null 2>/dev/null | grep -q "^${MCP_ALIAS}:"; then
+      say "${GREEN}✓ LGM MCP already configured — skipping.${RESET}"
+      LGM_MCP_CONFIGURED=1
+      return 0
+    fi
+  fi
+
+  # Non-interactive fast path — API key in env var.
+  if [ -n "${LGM_API_KEY:-}" ]; then
+    LGM_API_KEY_VALUE="$LGM_API_KEY"
+    return 0
+  fi
+
+  # No TTY → can't prompt safely.
+  if [ ! -t 0 ] && [ ! -r /dev/tty ]; then
+    say ""
+    say "${YELLOW}  No terminal detected — skipping the LGM MCP setup.${RESET}"
+    say "${GREY}  Re-run interactively, or set LGM_API_KEY=... before piping to sh.${RESET}"
+    return 0
+  fi
+
+  say ""
+  say "${CYAN}Connect the LGM MCP?${RESET}"
+  say "  The MCP lets Claude act inside your La Growth Machine workspace —"
+  say "  pull campaigns, push audiences, draft replies, all from chat."
+  say "  ${GREY}(an LGM account is required)${RESET}"
+  say ""
+  printf "  Do you already have an LGM account? [y/N]: "
+  ACCOUNT_REPLY="$(read_tty)"
+
+  case "$ACCOUNT_REPLY" in
+    y|Y|yes|YES) ;;
+    *)
+      pitch_lgm
+      return 0
+      ;;
+  esac
+
+  say ""
+  say "  ${CYAN}Grab your API key here:${RESET} ${API_KEY_URL}"
+  say "  ${GREY}(Settings → Integrations → API)${RESET}"
+  printf "  Paste your LGM API key (hidden): "
+  LGM_API_KEY_VALUE="$(read_secret_tty)"
+
+  if [ -z "$LGM_API_KEY_VALUE" ]; then
+    say ""
+    warn "  No API key entered — skipping MCP setup."
+    warn "  Re-run when you have it: ${API_KEY_URL}"
+    return 0
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 4 — register the LGM MCP with Claude Code
+#
+# Uses Claude Code's native HTTP MCP transport via `claude mcp add`.
+# The LGM API key is sent on every upstream call as `Authorization: Bearer <key>`.
+# No mcp-remote bridge, no OAuth dance, no browser step.
+# ─────────────────────────────────────────────────────────────────────
+install_claude_config() {
+  # Skip if Step 3 didn't collect the API key.
+  [ -z "$LGM_API_KEY_VALUE" ] && return 0
+
+  # The canonical method requires the `claude` CLI. If absent, surface the
+  # one-line command the user can run later, and don't fail the installer.
+  if ! command -v claude >/dev/null 2>&1; then
+    say ""
+    warn "  Claude Code CLI not found — can't auto-register the LGM MCP."
+    warn "  Install Claude Code: https://claude.ai/download"
+    warn "  Then run this once:"
+    warn "    claude mcp add --scope user --transport http ${MCP_ALIAS} ${MCP_URL} --header \"Authorization:Bearer YOUR_LGM_API_KEY\""
+    return 0
+  fi
+
+  # --scope user writes to ~/.claude.json (global) instead of the default
+  # local scope (.mcp.json in the current dir) — so the MCP is available in
+  # every project, regardless of where the installer was run from.
+  if run_quiet claude mcp add --scope user --transport http "$MCP_ALIAS" "$MCP_URL" \
+       --header "Authorization:Bearer $LGM_API_KEY_VALUE"; then
+    say "${GREEN}✓ LGM MCP registered with Claude Code (${MCP_ALIAS}, user scope).${RESET}"
+    say "${GREY}  Verify with: claude mcp list${RESET}"
+    LGM_MCP_CONFIGURED=1
+  else
+    warn "  claude mcp add failed. Run manually:"
+    warn "    claude mcp add --scope user --transport http ${MCP_ALIAS} ${MCP_URL} --header \"Authorization:Bearer YOUR_LGM_API_KEY\""
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 5 — print first-step prompts + soft "star the repo" nudge
+# ─────────────────────────────────────────────────────────────────────
+print_first_steps() {
+  [ "${LGM_INSTALL_NO_LAUNCH:-0}" = "1" ] && return 0
+
+  if ! command -v claude >/dev/null 2>&1; then
+    say ""
+    say "${YELLOW}Claude Code not found.${RESET}"
+    say "  Install: ${CYAN}https://claude.ai/download${RESET}"
+    say "  Then open Claude Code and try the prompts below."
+  fi
+
+  say ""
+  say "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+  if [ "$LGM_MCP_CONFIGURED" = "1" ]; then
+    say "${GREEN}  LGM GTM Skills + MCP ready.${RESET}"
+  else
+    say "${GREEN}  LGM GTM Skills installed.${RESET}"
+    say "${GREY}  MCP setup skipped — re-run this installer once your LGM account is ready.${RESET}"
+    say ""
+    say "${CYAN}  In the meantime, the skills are ready to use.${RESET}"
+    say "${GREY}    They work standalone — paste your data (deal export, campaign sequence,${RESET}"
+    say "${GREY}    ICP brief…) and Claude handles the rest. Connecting the MCP later upgrades${RESET}"
+    say "${GREY}    every skill to pull and push live data straight from your LGM workspace.${RESET}"
+  fi
+  say ""
+  say "  Start with one of these prompts in Claude Code:"
+  say ""
+  say "  ${CYAN}Build a prospect list${RESET}"
+  say "  ${GREY}→ \"Build me a Sales Navigator URL for SaaS founders in France, 50-500 employees.\"${RESET}"
+  say ""
+  say "  ${CYAN}Find your proven ICP${RESET}"
+  say "  ${GREY}→ \"Audit my biggest closed-won deals and tell me my proven ICP.\"${RESET}"
+  say ""
+  say "  ${CYAN}Write a campaign${RESET}"
+  say "  ${GREY}→ \"Write me a multichannel campaign for Heads of Sales at mid-market B2B SaaS.\"${RESET}"
+  say ""
+  say "  ${CYAN}Pressure-test a campaign before launch${RESET}"
+  say "  ${GREY}→ \"Challenge this campaign before I launch it: [paste your sequence]\"${RESET}"
+  say ""
+  say "  ${CYAN}See which campaigns drive pipeline${RESET}"
+  say "  ${GREY}→ \"Which of my campaigns is actually driving pipeline?\"${RESET}"
+  say ""
+  say "${GREY}  If this helped, ${RESET}${CYAN}star the repo${RESET}${GREY}: ${REPO_URL}${RESET}"
+  say "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+  say ""
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────
+print_logo
+ensure_node
+install_skills
+collect_account_and_key
+install_claude_config
+print_first_steps

--- a/skills/fuel-my-pipeline/won-deal-icp-finder/README.md
+++ b/skills/fuel-my-pipeline/won-deal-icp-finder/README.md
@@ -16,9 +16,19 @@ Example: you point it at your won deals and it surfaces two archetypes — "mid-
 
 ## Install
 
-Copy the skill folder into your Claude skills directory:
+**One-line (recommended)** — uses [`skills`](https://github.com/vercel-labs/skills) from Vercel Labs to install into Claude Code, Cursor, Codex, Amp + 30 other agents in one go:
 
 ```bash
+npx skills add LaGrowthMachine/gtm-system/skills/fuel-my-pipeline/won-deal-icp-finder
+```
+
+Add `-g` for a global install.
+
+**Manual install** — clone the repo and copy the skill folder yourself:
+
+```bash
+git clone https://github.com/LaGrowthMachine/gtm-system.git
+cd gtm-system
 cp -r skills/fuel-my-pipeline/won-deal-icp-finder ~/.claude/skills/
 ```
 

--- a/skills/fuel-my-pipeline/won-deal-icp-finder/SKILL.md
+++ b/skills/fuel-my-pipeline/won-deal-icp-finder/SKILL.md
@@ -134,7 +134,7 @@ Per archetype, call `visualize:show_widget` with `title` like `icp_archetype_fin
   For the persona row, append `<span style="color:var(--color-text-tertiary);">(inferred)</span>` when it isn't CRM-confirmed.
 - **`{ARCHETYPE_CRITERIA}`** — single-line restatement the button feeds to the search (e.g. `B2B SaaS and AI companies, 10-250 employees, US and Western Europe, targeting Growth/RevOps/Founder`).
 
-The button routes to **`sales-nav-search-builder`** (sibling skill, maintained by La Growth Machine) which returns a validated Sales Navigator search. After the last archetype, add one line: *if that skill isn't installed yet, it's in the [GTM System catalog](../../../README.md).* Translate titles/labels/lead-ins to the user's language; the `sendPrompt` payload stays English.
+The button routes to **`sales-nav-search-builder`** (sibling skill, maintained by La Growth Machine) which returns a validated Sales Navigator search. After the last archetype, add one line: *if that skill isn't installed yet, it's in the GTM System catalog.* Translate titles/labels/lead-ins to the user's language; the `sendPrompt` payload stays English.
 
 **Fallback if the visualizer is unavailable.** If `visualize:show_widget` fails, render each archetype as a **compact** Markdown block — title, the same criteria as bullet-free lines, and the criteria as a one-line `code` string the user can paste into `sales-nav-search-builder`. Keep it tight: no extra prose, no per-archetype essay.
 


### PR DESCRIPTION
## Ce que cette PR ajoute

Une couche d'installation pour les utilisateurs qui veulent récupérer les skills **et** brancher le MCP LGM dans Claude Code en une commande. Le repo expose déjà la voie skill-par-skill via `npx skills add` — cette PR ajoute le `curl | sh` qui fait tout d'un coup, plus un `CLAUDE.md` qui auto-onboarde les users qui clonent le repo.

---

## Fichiers

### `install.sh` (nouveau, racine, exécutable)

Script POSIX shell qui :

1. Vérifie Node.js / npx.
2. Installe les 5 skills via `npx skills add LaGrowthMachine/gtm-system` (Claude Code, Cursor, Codex).
3. Demande si l'user a un compte LGM.
   - **Oui** → prompt pour l'API key (saisie masquée via `stty -echo`).
   - **Non** → affiche un pitch LGM (4 bénéfices) + un lien register UTM-taggé, puis skip la config MCP sans toucher à Claude.
4. Enregistre le MCP via la commande canonique Claude Code :
   ```
   claude mcp add --transport http LaGrowthMachine \
     https://mcpapp.lagrowthmachine.com/mcp \
     --header "Authorization:Bearer <key>"
   ```
   La config va dans `~/.claude.json` (géré par la CLI Claude Code), l'API key passe en Bearer token. Transport HTTP natif — **pas de `mcp-remote`, pas de dance OAuth, pas de browser**. Le MCP est connecté dès le 1er restart de Claude Code.
5. Affiche des prompts de démarrage + un soft nudge "star the repo". Si le MCP est skip, ajoute une ligne précisant que les skills marchent en standalone.

**Idempotent** : un re-run détecte l'entrée `LaGrowthMachine` via `claude mcp list` et skip proprement. Atteignable via :
```
curl -fsSL https://raw.githubusercontent.com/LaGrowthMachine/gtm-system/main/install.sh | sh
```
Alternative "review-before-run" documentée dans le README. Env vars `LGM_API_KEY` / `LGM_INSTALL_NO_CLAUDE_PERMS` / `LGM_INSTALL_NO_LAUNCH` supportées pour CI / tests.

### `CLAUDE.md` (nouveau, racine)

Auto-onboarding pour les users qui clonent le repo et l'ouvrent dans Claude Code. Détecte si le MCP est configuré via `claude mcp list` ; si non, propose de lancer `sh install.sh` (en précisant que l'install est interactive). Si oui, liste les outils MCP (Audiences / Campaigns / Conversations / Workspace) et les 5 skills, groupés par catégorie v2.

### `README.md` (mis à jour)

Nouvelle section "Install everything in one command" avec le curl one-liner — décrivant fidèlement le flow interactif et l'enregistrement via `claude mcp add` (plus de fausse promesse "wired into settings.json automatically"). Les voies existantes préservées sous "Other ways to install" (npx skills add pour une skill, manual clone + cp -r, Claude.ai web pour le MCP). Catalog v2, table MCP, Tally et liens LGM intacts.

### Réalignement de `won-deal-icp-finder` (rattrapage du rebuild v2)

Deux corrections qui avaient été perdues quand la skill a été re-uploadée sur main :

- **SKILL.md** : suppression du lien Markdown en chemin relatif vers le catalogue dans l'output rendu en chat (mention "GTM System catalog" en texte simple) — même traitement que les 4 autres skills, conformément à la règle "no relative paths".
- **README.md** : alignement de la section Install sur le format hybride (one-liner `npx` + fallback `git clone`) utilisé dans toute la librairie.

---

## Décisions clés

| Sujet | Choix |
|---|---|
| URL MCP | `https://mcpapp.lagrowthmachine.com/mcp` |
| Auth | API key en Bearer token (`Authorization:Bearer <key>`) — testé en direct contre le serveur, accepté |
| Méthode d'enregistrement | `claude mcp add --transport http` (canonique Claude Code, transport HTTP natif — comme Lemlist) |
| Stockage config | `~/.claude.json` géré par la CLI Claude Code (pas `settings.json` direct) |
| Alias | `LaGrowthMachine` → matche `mcp__LaGrowthMachine__*` que les 5 skills détectent, zéro refacto skill |
| Install interactive | Oui — l'user doit avoir un compte LGM + paste son API key |

---

## Tests end-to-end passés (local)

| Path | Statut |
|---|---|
| User existant, nominal flow | ✅ `claude mcp list` → Connected, "list my LGM campaigns" → 25/389 campagnes live |
| No account → pitch + register link, MCP skip propre | ✅ |
| API key vide → warn + skip, pas de config partielle | ✅ |
| Non-interactif via `LGM_API_KEY=...` | ✅ MCP enregistré sans prompt |
| Idempotence (re-run) | ✅ "already configured — skipping" |

---

## Pas touché

Les 4 skills `get-qualified-meetings` + `sales-nav-search-builder` sont intactes. Seul `won-deal-icp-finder` reçoit les 2 micro-fixes de réalignement décrits ci-dessus (cohérence cross-library).

→ **On ne merge pas — Brice valide.**