### PR TITLE
CLAUDE.md: refresh MCP tool list, OAuth flow, and skill catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,20 +1,20 @@
 # LGM GTM Skills — Claude setup
 
-You are looking at the **GTM System repo** maintained by [La Growth Machine](https://lagrowthmachine.com). It bundles a library of public Claude skills (sourcing, list building, campaigns, copywriting, analytics) and an MCP server that lets Claude act directly inside the user's LGM workspace.
+You are looking at the **GTM System repo** maintained by [La Growth Machine](https://lagrowthmachine.com). It bundles a library of public Claude skills (sourcing, list building, campaigns, copywriting, analytics, reply handling) and an MCP server that lets Claude act directly inside the user's LGM workspace.
 
 ## First-time setup
 
-Check if the LGM MCP is already configured by running `claude mcp list` (look for a line starting with `LaGrowthMachine:`). The installer registers the MCP via `claude mcp add --scope user --transport http`, which stores the config in `~/.claude.json` at user scope (available in every project) — not in `settings.json` directly. If the `claude` CLI isn't available, ask the user whether they've already run `sh install.sh`.
+Check if the LGM MCP is already configured by running `claude mcp list` (look for a line starting with `LaGrowthMachine:`). The installer registers the MCP via `claude mcp add --scope user --transport http`, which stores the config in `~/.claude.json` at user scope (available in every project). If the `claude` CLI isn't available, ask the user whether they've already run `sh install.sh`.
 
 **If it is NOT configured**, proactively tell the user:
 
-> "I can see this is the LGM GTM Skills repo. Would you like me to install the LGM MCP and skills? It takes ~1 minute — I'll run `sh install.sh` for you. The installer is interactive: it'll ask whether you have an LGM account and prompt for your API key (hidden) to wire the MCP."
+> "I can see this is the LGM GTM Skills repo. Would you like me to install the LGM MCP and skills? It takes ~1 minute — I'll run `sh install.sh` for you. On first use, a browser tab opens to sign in to La Growth Machine (OAuth) — new accounts can be created from that tab. No API key to copy, nothing to paste."
 
 If they say yes, run `sh install.sh` and confirm when done.
 
 **If it IS configured**, present the onboarding to the user:
 
-1. Confirm MCP is connected and list the available MCP tools grouped by category (Audiences, Campaigns, Conversations & leads, Workspace).
+1. Confirm MCP is connected and list the available MCP tools grouped by category (Audiences, Campaigns, Inbox, Send, Workspace, LinkedIn, BigQuery).
 2. List the available GTM Skills grouped by category.
 3. Show the suggested first-steps table.
 4. Ask: *"What would you like to do?"*
@@ -29,28 +29,51 @@ Once the MCP is connected and skills are installed, two layers work together.
 
 ### Layer 1 — LGM MCP (Claude acts inside La Growth Machine)
 
-The MCP gives Claude direct access to the user's LGM workspace. No copy-paste, no tab switching.
+The MCP gives Claude direct access to the user's LGM workspace. No copy-paste, no tab switching. Tools are exposed under the namespace `mcp__LaGrowthMachine__*`.
 
 **Audiences**
 - `create_audience_from_linkedin_url` — create an audience directly from a Sales Navigator search URL
 - `get_audience` — fetch an existing audience by ID
-- `get_audience_leads` — list all leads in an audience
+- `get_audience_leads` — list all leads in an audience (paginated)
 
-**Campaigns**
+**Campaigns — read**
 - `list_campaigns` — list all campaigns in the workspace
-- `get_campaign_messages` — fetch the message sequence of a campaign
-- `get_campaign_stats` — get open rates, reply rates, and performance data
+- `get_campaign_stats` — open rates, reply rates, meetings booked, performance data
+- `get_campaign_messages` — fetch the messages of a campaign's sequence
+- `get_campaign_steps` — fetch the sequence structure (channels, waits, branches)
 
-**Conversations & leads**
-- `get_lead_conversations` — fetch all conversations for a specific lead
-- `get_conversation_messages` — read the full message thread of a conversation
-- `get_lead_logs` — get the activity log for a lead (visits, clicks, replies)
+**Campaigns — build / edit**
+- `duplicate_campaign` — clone an existing campaign as the starting point for a new one
+- `add_campaign_step_message` — add a message to a specific step of a draft campaign
+- `edit_campaign_message` — edit an existing message in a draft campaign
+
+**Inbox / conversations — read**
+- `get_lead_conversations` — all conversations for a specific lead
+- `get_conversation_messages` — the full message thread of a conversation
+- `get_lead_logs` — the activity log for a lead (visits, clicks, replies)
+- `get_unread_conversations` — inbox: unread conversations
+- `get_conversations_to_reply` — inbox: conversations waiting for a reply
+- `get_favourite_conversations` — inbox: starred conversations
+- `search_conversations` — search the inbox by keyword, lead, campaign, status
+
+**Inbox / conversations — actions**
+- `send_email_message` — send an email reply in a conversation
+- `send_linkedin_message` — send a LinkedIn reply in a conversation
+- `snooze_conversation` / `unsnooze_conversation` — snooze a thread for later
+- `archive_conversation` / `unarchive_conversation` — archive / restore a thread
 
 **Workspace**
-- `list_identities` — list all identities (LinkedIn accounts, email accounts) in the workspace
+- `list_workspaces` — list the workspaces the user has access to
+- `list_members` — list the members of the current workspace
+- `list_identities` — list all identities (LinkedIn accounts, email accounts)
 - `save_identity_preference` — set a preferred identity for outreach
 
-Tools are exposed under the namespace `mcp__LaGrowthMachine__*`.
+**LinkedIn**
+- `get_linkedin_post` — fetch a LinkedIn post and its engagers (likers, commenters)
+
+**BigQuery**
+- `execute_bigquery_query` — run a BigQuery query against LGM data
+- `get_bigquery_logs_guide` — get the guide to LGM's log schema (what tables and fields exist)
 
 ---
 
@@ -61,12 +84,14 @@ Skills guide Claude through complex GTM workflows. Just describe what you want. 
 **Fuel my pipeline** — sourcing, list building, ICP
 
 - `sales-nav-search-builder` — turn a natural-language ICP into a precise LinkedIn Sales Navigator search URL, ready to import as an LGM audience
+- `post-to-campaign` — turn a LinkedIn post into a ready-to-launch campaign: scrape the post's likers and commenters into an audience and fill a draft sequence
+- `audience-icp-filter` — filter an existing audience against an ICP; sorts every lead into match / needs review / no match, strips your team and competitors, never silently drops anyone
 - `won-deal-icp-finder` — audit your biggest closed-won deals to find your proven ICP and a look-alike target list
 
 **Get qualified meetings** — campaigns, copywriting, sequences
 
-- `multichannel-campaign-builder` — generate a complete LinkedIn + email sequence from a natural-language brief
-- `campaign-challenger` — benchmark a campaign copy against your existing campaigns and return prioritized fixes before launch
+- `multichannel-campaign-builder` — generate a complete LinkedIn + email sequence from a natural-language brief, and create it as a draft campaign in LGM
+- `campaign-challenger` — benchmark a campaign copy against your existing campaigns, return prioritized fixes, and apply them back into the campaign
 - `campaign-impact-analyzer` — rank campaigns by real revenue impact by cross-referencing LGM campaigns with HubSpot deals
 - `weekly-performance-advisor` — build a two-tab weekly cockpit from your LGM data: replies to handle, campaigns to fix, and reply-volume trends
 
@@ -85,13 +110,16 @@ Suggest one of these depending on what the user wants to do:
 | They want to… | Suggest |
 |---|---|
 | Build a prospect list | Use `sales-nav-search-builder` |
+| Sequence people who engaged with a LinkedIn post | Use `post-to-campaign` |
+| Filter or segment an existing audience against an ICP | Use `audience-icp-filter` |
 | Find their proven ICP from deals | Use `won-deal-icp-finder` |
 | Write a campaign from scratch | Use `multichannel-campaign-builder` |
 | Pressure-test a campaign before launch | Use `campaign-challenger` |
 | See which campaigns drive pipeline | Use `campaign-impact-analyzer` |
 | See what to do this week / campaign health | Use `weekly-performance-advisor` |
 | Handle or draft replies to their inbox | Use `reply-draft-assistant` |
-| Pull live campaign data | Call the MCP directly (e.g. `list_campaigns`, `get_campaign_stats`) |
+| Pull live campaign data ad hoc | Call the MCP directly (e.g. `list_campaigns`, `get_campaign_stats`) |
+| Run a custom analytics query | Call the BigQuery tools (`execute_bigquery_query`, `get_bigquery_logs_guide`) |
 
 ---
 


### PR DESCRIPTION
## Ce que cette PR corrige

`CLAUDE.md` avait drifté sur 3 fronts depuis le merge de PR #3 (2 juin) — il ne reflétait plus l'état actuel du MCP ni du catalog.

### 1. Tools MCP — passe de 11 à 30 outils listés

Le MCP expose aujourd'hui 30 tools sous `mcp__LaGrowthMachine__*`. L'ancien CLAUDE.md en listait 11. Ajouté :

- **Campaigns — build / edit** (4) — `duplicate_campaign`, `add_campaign_step_message`, `edit_campaign_message`, `get_campaign_steps`. C'est ce qui permet à `multichannel-campaign-builder` et `campaign-challenger` d'agir nativement.
- **Inbox — read** (4) — `get_unread_conversations`, `get_conversations_to_reply`, `get_favourite_conversations`, `search_conversations`. Utilisés par `reply-draft-assistant` et `weekly-performance-advisor`.
- **Inbox — actions** (6) — `send_email_message`, `send_linkedin_message`, `snooze_conversation`, `unsnooze_conversation`, `archive_conversation`, `unarchive_conversation`. Grosse omission — c'est le core de reply-draft-assistant.
- **Workspace** (+2) — `list_workspaces`, `list_members` ajoutés aux 2 déjà listés.
- **LinkedIn** (1, nouveau groupe) — `get_linkedin_post`. Utilisé par `post-to-campaign`.
- **BigQuery** (2, nouveau groupe) — `execute_bigquery_query`, `get_bigquery_logs_guide`. Analytics avancée.

### 2. OAuth flow

Le paragraphe "First-time setup" annonçait encore un prompt interactif pour l'API key. [7a66dec](https://github.com/LaGrowthMachine/gtm-system/commit/7a66dec) a switché le MCP en OAuth via `mcp.lagrowthmachine.com` — plus de clé à copier, un tab browser s'ouvre. Le pitch d'onboarding a été mis à jour en conséquence.

### 3. Catalog skills

- **`post-to-campaign`** — présent dans le catalog root depuis PR #? mais absent de CLAUDE.md. Ajouté sous Fuel my pipeline.
- **`audience-icp-filter`** — nouveau, mergé via PR #8. Ajouté sous Fuel my pipeline.
- **Suggested first steps table** — 2 nouvelles rows (LinkedIn post → post-to-campaign, filter audience → audience-icp-filter) + 1 pour la BigQuery (analytics ad hoc).

## Ce qui n'est PAS touché

Structure, tone, layout des 4 catégories. Seule la couche factuelle (tools listés, install flow, catalog) a été refresh.