### PR TITLE
audience-icp-filter: bounded pass 2 + execution discipline + widget file

### DIFF
--- a/skills/fuel-my-pipeline/audience-icp-filter/SKILL.md
+++ b/skills/fuel-my-pipeline/audience-icp-filter/SKILL.md
@@ -26,10 +26,18 @@ If the user hasn't imported yet, tell them to do that first, then come back with
 
 Any audience is mostly noise: the user's own colleagues are in it, competitors are watching, and a third of the job titles are unreadable. This skill checks whether the data can support the ICP the user wants, asks what that ICP actually is, sorts the list, and writes the segments back as complementary audiences.
 
+## Execution style — fast and quiet
+
+This skill does a lot of steps. Two rules keep it usable:
+
+- **Minimal narration.** Do the reasoning and the tool calls, but do **not** narrate each step to the user ("page 1 loaded", "the param is skip not offset", "wrapping the payload"…). The user wants the *result*, not a play-by-play. Stay silent through the pipeline and speak only when you present the widgets — one or two sentences of framing, no more. Think as hard as you like; just don't type it out.
+- **Parallelize and batch.** Fetch the lead pages **concurrently** (issue the `get_audience_leads` calls for all pages in one batch). Keep only the scored fields when you normalise (`leadId, jobTitle, companyName, proEmail, shortBio, location, industry`) — not all 40 columns — so the payloads stay small.
+- **Never re-read the whole audience in pass 2.** This was the measured bottleneck: reviewing 250 leads one by one took 8 minutes. Pass 1 hands you a bounded `pass2_queue` — only the genuinely suspect leads (ambiguous, bio-inferred matches, agency/freelance matches, and leads dropped on a soft geo/industry miss). **Pass 2 reviews only that queue**, typically a few dozen. If the queue is still large (60+), fan it out: a couple of parallel sub-agents on **Sonnet** splitting the queue, reserving deeper reasoning only for the final ambiguous handful. A clean, on-target audience produces a queue of ~15–25; a full re-read is never needed.
+
 ## Workflow
 
 **Step 0 — Load the list.**
-From an LGM audience (`list_audiences` → `get_audience_leads`, paginating at 100/page until you have `total`), or from a CSV. Normalise to one object per person: `leadId` (or `firstname`+`lastname`), `jobTitle`, `companyName`, `proEmail`, plus `shortBio`, `location`, `industry` when present.
+From an LGM audience (`list_audiences` → `get_audience_leads`) or a CSV. **Pagination: the parameter is `skip` (not `offset`), 100 max per page** — so page 2 is `skip:100`, page 3 `skip:200`. Read `total` from the first page and fire the remaining pages **in one concurrent batch**. Normalise to one object per person: `leadId` (or `firstname`+`lastname`), `jobTitle`, `companyName`, `proEmail`, plus `shortBio`, `location`, `industry` when present.
 
 **Step 1 — Coverage gate. Run this before asking about the ICP.**
 ```bash
@@ -45,14 +53,14 @@ python3 scripts/build.py spec.json > pass1.json
 ```
 It refuses invalid input rather than emitting a best-effort sort. If it errors, fix the spec — never work around it by classifying manually.
 
-**Step 4 — Pass 2, semantic. Mandatory.** Read every bucket, `match` first. Write overrides with reasons:
+**Step 4 — Pass 2, semantic. Mandatory — but bounded.** Pass 1's output carries a `pass2_queue`: the only leads worth a human/LLM look. **Review that queue, not the whole audience** (see *The pass-2 queue* below). Each queued lead has a `_flag` telling you why it's there. Resolve each into `match` or `no_match`, write the overrides with reasons, then re-validate:
 ```bash
 python3 scripts/build.py --adjudicate review.json
 ```
 
-**Step 5 — Present** counts, segments, and what pass 2 changed.
+**Step 5 — Present** the single result artifact (coverage + segmentation + the state-driven action zone). If a residue remains it embeds the inline triage deck; otherwise it shows the Create CTA directly (see *Zone 3 — one action, review then create*).
 
-**Step 6 — Write complementary audiences** back (see below), or export a CSV.
+**Step 6 — Create the audience** after review: `[icp]` = confident matches + whatever the user kept in the deck. Then offer a CSV as a secondary option, only if they want it — never auto-generate one.
 
 ## The coverage gate
 
@@ -88,11 +96,28 @@ If the user declines enrichment, proceed — but state which criteria you droppe
 | `Founder @ Stealth Mode` | **review** | Almost certainly in ICP. |
 | A title in a language the taxonomy misses | **review** | Often a clear match. |
 
-**Review every bucket, not just `review`.** The `match` bucket is where a false positive costs you — that lead gets sequenced. Read `match` first.
+**False positives live in `match`, not just `review` — but you don't re-read all matches.** The `pass2_queue` already pulls the risky matches (bio-inferred, agency/freelance) alongside the ambiguous and the soft-dropped. Trust the queue: it's how you catch the false positives without paying the 8-minute cost of re-reading confident matches.
+
+**Pass 2 is Claude's job, not the user's.** The whole promise of this skill is that the user does *not* hand-sort a list. A 50-lead review bucket handed to the user is a failure, not a result. In pass 2 **you** read each queued lead's full record — job title, bio, industry, company — and resolve as many as you honestly can into `match` or `no_match`, leaving only the genuinely ambiguous handful for the user. Working the queue down is the deliverable; surfacing it untouched is not.
+
+### The pass-2 queue
+
+`build.py` returns `pass2_queue` — the bounded set of leads pass 2 should actually inspect, each tagged with a `_flag`. **Do not review anything outside it**; leads not in the queue are confident enough to trust, and re-reading them is the 8-minute mistake.
+
+| `_flag` | What it is | What to check |
+|---|---|---|
+| `ambiguous` | the whole `review` bucket | resolve to match / no_match, or leave for the deck |
+| `bio-inferred match` | matched via the bio, not the title | confirm the bio really means an in-ICP function |
+| `agency/freelance — confirm it's the ICP` | a match whose company/bio reads like an agency, freelancer or consultant | keep if they're a real buyer, drop if they're a service provider |
+| `dropped on geo/industry — check the variant` | right seniority + function, but failed the location/industry substring | rescue if the label is just a variant of an in-ICP geo/industry |
+
+The queue also catches the exact failures from real runs: agencies/freelancers sitting in `match`, and real SaaS companies wrongly in `no_match` because LinkedIn labelled them "Technology, Information and Internet" instead of "Software". On a clean, on-target audience the queue is ~15–25 leads; that's the whole of pass 2's work.
 
 The script re-runs the same reconciliation on your overrides, and rejects an override on a lead that doesn't exist, an invalid bucket, a duplicate, or a reclassification with no substantive reason. You cannot lose a lead in pass 2 either.
 
 Never present pass-1 output as the final answer. If you are about to hand over results without having run pass 2, stop and run it.
+
+**If the review bucket is large, the fix is usually upstream.** Pass 1 already reads `shortBio` as a fallback when the title is silent, so a big review bucket typically means either the audience isn't enriched (check coverage) or the ICP is under-specified (a founder rule left unanswered, a function list too narrow). Diagnose the cause and say it — don't just move 40 leads by hand.
 
 ## The ICP Q&A
 
@@ -110,6 +135,36 @@ Ask before classifying. The same audience feeds very different ICPs.
 
 If the ICP is vague ("good leads", "decision makers"), push once for specifics. A vague ICP produces a huge review bucket — the original problem with extra steps.
 
+## The spec format
+
+`build.py` reads one JSON object:
+
+```json
+{
+  "icp": {
+    "seniority": ["founder_c", "vp_head", "manager_lead"],
+    "functions": ["sales", "growth_marketing", "revops"],
+    "founder_qualifies_regardless_of_function": false,
+    "locations": ["France", "Paris"],
+    "industries": ["Software"]
+  },
+  "exclusions": {
+    "domains": ["yourcompany.com"],
+    "companies": ["Your Company"],
+    "keywords": ["competitor-a", "competitor-b"]
+  },
+  "leads": [ { "leadId": "...", "jobTitle": "...", "companyName": "...", "proEmail": "...", "shortBio": "...", "location": "...", "industry": "..." } ]
+}
+```
+
+`locations` and `industries` are optional — include them only when the coverage gate says the data supports them. Each lead needs a `leadId`, or both `firstname` and `lastname`. For `--adjudicate`, pass `{"result": <pass1 output>, "overrides": [{"_key": "...", "bucket": "...", "reason": "..."}]}`.
+
+**Geo matches on substring, so list the real variants.** Enrichment writes `"Greater Paris Metropolitan Region"`, `"Greater Lyon Area"` — none contain the word `"France"`, so `locations: ["France"]` would wrongly drop them. Glance at the actual `location` values (`--coverage` or a quick scan) and include the metros/regions that appear.
+
+**Industry is auto-expanded — you don't hand-list the variants.** When your `industries` include a known bucket (`saas`, `software`, `tech`, `fintech`, `healthtech`, `ecommerce`), `build.py` expands it to the LinkedIn labels that mean the same thing (`saas` → `Software Development`, `Technology, Information and Internet`, `IT Services`, …). Just pass `["saas"]`. For a bucket not in the synonym map, list the variants yourself, or let the `dropped on geo/industry` queue flag surface the misses for pass 2.
+
+**`CMO`, `CRO`, `CFO` etc. are abbreviations the title patterns catch for seniority but not for function.** A bare "CMO @ Acme" resolves as founder/C-level but lands in `review` for function. In pass 2, read these as their function (CMO → marketing, CRO → sales) rather than leaving them ambiguous.
+
 ## Seniority tiers
 
 Evaluated top-down, first match wins — which is why `Chief Executive Officer` resolves as founder/C-level rather than as an "executive" IC.
@@ -122,6 +177,8 @@ Evaluated top-down, first match wins — which is why `Chief Executive Officer` 
 | `ic` | Account Executive, SDR, BDR, Specialist, Coordinator, Analyst, Consultant, Engineer, Intern, Junior |
 
 The `Chief … Officer` pattern is deliberately broad — it catches real C-levels, and pass 2 removes the HR/medical/happiness false positives.
+
+**Title first, bio as fallback.** Detection runs on the job title; when the title carries no seniority or no function signal, pass 1 falls back to `shortBio` (now that enrichment exposes it). A `Managing Director` whose bio reads "Développement commercial" is matched on that bio. On a real 150-lead audience, reading the bio cut the review bucket by ~60%. A bio-inferred match is flagged in its reason ("inferred: function from bio") so pass 2 can give it a second look.
 
 ## Function tiers
 
@@ -148,7 +205,7 @@ Three failure modes seen on real data, all handled in pass 1:
 
 Always seed exclusions with the user's **own** company and domain — the most common leak and the most embarrassing.
 
-Pass 2 extends this: exclude competitors the user didn't list but you recognise, and say which ones you added.
+Pass 2 extends this: exclude competitors the user didn't list but you recognise, and say which ones you added. But **a competitor name matching inside a `bio` (a tool the lead mentions) is not the same as their employer** — don't exclude on a bio-only competitor hit. In testing, "lemlist"/"expandi" appeared in leads' bios as tools they use, and excluding them was wrong; check it's the employer/domain before dropping.
 
 ## The buckets
 
@@ -167,55 +224,87 @@ A `review` bucket around a third is normal on thin data. Say so plainly and name
 
 | Tempting | Why it fails | Do instead |
 |---|---|---|
+| Narrating every step to the user | Slow, noisy, buries the result | Work quietly, present the widgets |
 | Eyeballing the list and sorting it yourself | Silent, unauditable, leaks the user's own team | Run pass 1 |
+| Excluding on a competitor name found only in the bio | It's a tool they mention, not their employer | Exclude on employer/domain, not bio-only |
+| Auto-generating a CSV | The primary outcome is audiences in LGM | Offer CSV as a secondary, on request |
+| Dumping the full match list below the widget | Clutter; the verdict is in the widget, the audience is in LGM | Offer it in one line; show only if asked |
+| Two competing CTAs (review + create) | The user doesn't know which to click | Review first, create after |
 | Shipping pass-1 output as final | HR and medical C-levels sit in `match` | Always run pass 2 |
-| Only reviewing the `review` bucket in pass 2 | False positives live in `match`, and they get sequenced | Read `match` first |
+| Re-reading all 250 leads in pass 2 | 8-minute bottleneck; most are obvious | Review only the `pass2_queue` |
+| Writing the matches one `create_lead` at a time, narrated | The slow tail of the run | Fire concurrently in waves of ~45 (50/10s limit), silently |
 | Skipping the coverage gate | You offer geo filtering on empty data and dump the list into `review` | Run `--coverage` first |
 | Filtering on a criterion the data can't support | Produces a confident, meaningless result | Drop it and say so |
 | Guessing the ICP from the audience name | The same audience feeds very different ICPs | Run the Q&A |
 | Dropping ambiguous leads to keep output tidy | Hides real pipeline | Route to `review` |
 | Reaching for email enrichment | 5 credits vs 1, and useless for ICP scoring | Profile enrichment only |
-| Improvising the result layout | The user has to relearn the output every run | Always the four fixed zones |
-| Hiding the coverage zone when data is clean | The layout shifts run to run | Keep it, with green chips |
+| Improvising the result layout | The user has to relearn the output every run | Always the three fixed zones |
+| Hiding the coverage zone when data is clean | The layout shifts run to run | Keep it, with chips |
+| Handing the review bucket to the user as a list | That's the hand-sorting the skill exists to kill | Drain it in pass 2, deck the residue |
 
 ## Writing complementary audiences (LGM connected)
 
-The source audience is **left untouched** — it stays the raw record. Add two audiences alongside it:
+The source audience is **left untouched** — it stays the raw record. The main output is one new audience:
 
-| Bucket | Audience name |
+| Audience | Contents |
 |---|---|
-| ICP matches | `[icp] <source audience name>` |
-| Needs review | `[review] <source audience name>` |
+| `[icp] <source audience name>` | confident matches **+** the leads kept in the inline triage deck |
 
-`no_match` and `excluded` are reported but not written — an audience of people you decided not to contact is clutter.
+`no_match` and `excluded` are reported but not written — an audience of people you decided not to contact is clutter. A `[review] <source audience name>` audience is only created in the fallback case where the user declines to triage the deck at all — then park the residue there for later rather than losing it.
 
-Writing a lead to another audience is non-destructive: it is merged on identity, not moved, so the source audience survives intact as the audit trail. Store the classification reason on the lead (a custom attribute) so the decision stays auditable in-app later.
+Writing a lead to another audience is non-destructive: `create_lead` (with `audience: "[icp] …"`) merges on identity, not moves, so the source audience survives intact as the audit trail. Store the classification reason on the lead (a custom attribute) so the decision stays auditable in-app later.
 
-Confirm before writing, and state exactly how many leads go where.
+**Write the whole audience in parallel, quietly — this is the run's other bottleneck.** There is no bulk endpoint, so each match is one `create_lead` call, but they are independent: fire them **concurrently**, not one-then-the-next with a message between each. LGM's rate limit is **50 calls / 10 s**, so send them in concurrent waves of ~45 and pause ~10 s between waves; 140 leads finishes in ~30 s instead of minutes. Don't narrate the batches ("20 attached", "40 done"…) — write silently and report only the final line. If it's large (150+), hand the write to a sub-agent so the main thread stays clean.
+
+Confirm before writing, and state exactly how many leads go where — once, at the end.
 
 ## Output & LGM handoff
 
-The result **always** renders through the same widget, with the same four zones in the same order. Uniformity is the point: the user learns to read one layout once. Never improvise a different presentation, never reorder or drop a zone.
+The whole result is **one** `visualize:show_widget` render — a single artifact, `references/result-widget.html`. Fill its placeholders and the `CFG`/`L` config; do not rebuild or restyle it, and never split it into two widgets. Three fixed zones, same order every run:
 
-Render it with `visualize:show_widget`. Zone order and why:
+1. **Data coverage** — first, because it conditions everything below. Keep it visible even when every field is fine (chips, no note).
+2. **Segmentation** — the stacked bar + the buckets. The `review` row is highlighted and points **↓ below** (the `L_BELOW` label) so the user knows those leads are handled in zone 3.
+3. **Action** — the only action area, state-driven. It **replaces** the old "audiences to create" recap (which just repeated numbers already read).
 
-1. **Data coverage** — first, because it conditions everything below. Seeing that geography was unavailable *before* reading the counts stops the user assuming the sort is complete. Keep it visible even when every field is fine (green chips, no note) — a layout that changes shape run to run defeats the purpose.
-2. **Segmentation** — the stacked bar plus the four buckets with counts.
-3. **Pass 2** — what you reclassified and why. Show it **even when nothing moved** ("Pass 2 — 0 reclassified"); it is the evidence that pass 2 ran.
-4. **Audiences to create** — the names, the counts, and the reminder that the source is untouched.
+**Pass 2 does not get a zone.** What you reclassified is an audit detail — one prose line below the widget ("Pass 2: moved 3 — 2 rescued from a bio signal, 1 competitor excluded"), not a card.
+
+### Zone 3 — one action, review then create
+
+The artifact drives zone 3 from `CFG.mode`, so the user always sees exactly one primary path:
+
+| `CFG.mode` | When | Zone 3 shows |
+|---|---|---|
+| `"enrich"` | coverage blocked an ICP criterion | the green enrichment CTA, nothing else — you don't reach review/create until the data supports the ICP |
+| `"review"` | coverage clean **and** a pass-2 residue remains | an **inline triage deck** over the residue; when the last card is decided it becomes the green Create CTA automatically |
+| `"create"` | coverage clean **and** no residue | the green Create CTA directly |
+
+So the flow is **review first, then create**, in one artifact — no two competing CTAs. Kept cards join the confident matches in `[icp]`; skipped ones stay out; there's normally no `[review]` audience to make (only the fallback where the user declines to triage at all).
+
+### Filling it
+
+Zone 1/2 placeholders: `{COVERAGE_CHIPS}` (one `<span class="chip">Field NN%</span>` per sufficient field, `chip miss` per insufficient), `{COVERAGE_NOTE}` (a `<p class="why">` consequence-first, omitted when clean), `{PCT_*}` (sum to 100), `{N_*}`, and the `{L_*}` labels in the user's language.
+
+Zone 3 config (JS object near the bottom of the template):
+- `CFG.mode` — `"enrich"` / `"review"` / `"create"` per the table.
+- `CFG.audience` — the source audience name (the Create CTA renders `[icp] <that name>`).
+- `CFG.matchBase` — the count of confident matches (`N_MATCH`); the Create total = base + kept.
+- `CFG.enrich` — `{n, why}`, used only in enrich mode.
+- `CFG.leads` — one object per residual lead: `{id, fn, ln, title, co, loc, ind, bio, why}` (`id` = real `leadId`, `why` = the reason in plain language). `[]` when there's no residue.
+
+The Create button's `sendPrompt` returns the confident-match count + the kept `leadId`s. **That is the write trigger:** create `[icp]` from the matches + kept, writing in parallel (see *Writing the ICP audience*), then report the final count.
+
+Below the widget, in prose: **one line** on what pass 2 changed. **Do not print the match list by default** — the widget already gives the verdict and the audience is written into LGM, so a 37-row dump is clutter. Offer it in a single sentence ("want the list of matches, or a CSV?") and produce the Markdown table or the CSV **only if the user asks**.
 
 ### Hard rules
 
-- **No copyable text inside the widget.** It renders in a sandboxed iframe with no clipboard. The match table (name, title, company, why) goes **below** the widget as native Markdown, where the renderer gives it a working copy button.
-- **Two buttons maximum, exactly one of them green.** Green is the LGM action colour and is reserved for action — never decoration, never a data fill.
-- **The green button goes to whichever action serves the user right now.** If the coverage gate blocked ICP criteria, green is *enrichment* (creating audiences on incomplete data would be the wrong default). Otherwise green is *create the audiences*. The other action becomes the outlined ghost button. Zones never move; only the destination of the green changes.
-- **Visible labels follow the user's language.** Audience names (`[icp] …`, `[review] …`) and every `sendPrompt(...)` string stay in **English** regardless.
-- Bar widths are the bucket percentages; the four segments must sum to 100%.
-- No CSV export button — offer it in text if the user wants one.
+- **No copyable text inside the widget** (sandboxed iframe, no clipboard). If the user asks for the match list, it goes **below** as native Markdown — but don't volunteer it unprompted.
+- **Green (`#3DDC84`) is reserved for the primary action only** — the Create CTA and the enrichment CTA. Never elsewhere. The triage buttons are neutral (Keep = navy fill, Skip = outline); only their small icons carry colour: **✓ on a green circle, ✕ on a coral circle (`#F07060`), both with a navy glyph** (contrast-checked: navy-on-green 9.6:1, navy-on-coral 5.9:1; white fails on both).
+- **Do not auto-generate a CSV.** The primary outcome is the audience in LGM. A CSV is a **secondary** option offered in one line, produced only if the user says yes.
+- Bar widths are the bucket percentages; segments sum to 100%.
 
 ### Colour and contrast — measured, not eyeballed
 
-The palette is fixed by the LGM brand system: background `#F2F0F5`, ink `#1E1735`, action green `#3DDC84`. Every text colour below was contrast-checked against the grey background and clears the 4.5:1 body threshold.
+Palette fixed by the LGM brand: background `#F2F0F5`, ink `#1E1735`, action green `#3DDC84`, coral `#F07060`. Contrast-checked against the grey:
 
 | Token | Hex | On `#F2F0F5` | Use |
 |---|---|---|---|
@@ -224,126 +313,17 @@ The palette is fixed by the LGM brand system: background `#F2F0F5`, ink `#1E1735
 | Ink 3 | `#6E6685` | 4.8:1 | Zone labels, hints |
 | Muted | `#8A82A0` | 3.2:1 | **Borders and fills only — never text** |
 
-Three consequences that are easy to get wrong:
+1. **Never set text in green** (`#3DDC84` on grey = 1.6:1). Green is a background only.
+2. **Glyphs on the green/coral icon circles and the green CTA circle are navy `#1E1735`, never white.**
+3. **Never build hierarchy with opacity** — a tint ramp collapses (35%/18% = 2.1:1/1.4:1). Use the solid tokens; give the lightest bar segment a `#8A82A0` border.
 
-1. **Never set text in green.** `#3DDC84` on the grey is 1.6:1 — illegible. Green is a background only.
-2. **Content on the green circle is `#1E1735`, never white.** White on green is 1.8:1; navy on green is 9.6:1.
-3. **Never build hierarchy with opacity.** A four-step tint ramp collapses: navy at 35% and 18% measure 2.1:1 and 1.4:1 and disappear. Use the solid tokens above, and give the lightest bar segment a `#8A82A0` border so it reads by its outline rather than its lightness.
+### After creating the audience
 
-### The widget
+Confirm what landed where in one line ("Created `[icp] …` with 140 leads — 135 auto-matched + 5 you kept"). Then offer, in a single sentence, both secondary options — the match list and a CSV — and produce either **only if the user asks**. Never dump the list or pre-build the CSV.
 
-```html
-<h2 class="sr-only">{ACCESSIBLE_SUMMARY}</h2>
-<style>
-.lg3{--bg:#F2F0F5;--ink:#1E1735;--ink2:#5A5170;--ink3:#6E6685;--muted:#8A82A0;--green:#3DDC84;
-background:var(--bg);color:var(--ink);border-radius:24px;padding:28px 30px;margin:.5rem 0;
-position:relative;overflow:hidden;font-family:'PP Telegraf',system-ui,-apple-system,sans-serif;font-size:14px;line-height:1.5}
-.lg3 *{position:relative;z-index:1}
-.lg3 .brick{position:absolute;z-index:0;border-radius:21px;overflow:hidden;background:#fff;transform:rotate(30deg)}
-.lg3 h3{font-size:21px;font-weight:700;margin:0 0 2px;letter-spacing:-.01em;color:var(--ink)}
-.lg3 .sub{font-size:13px;color:var(--ink2);margin:0 0 26px}
-.lg3 .z{font-size:10.5px;letter-spacing:.09em;text-transform:uppercase;color:var(--ink3);margin:0 0 10px;font-weight:700}
-.lg3 .card{background:#fff;border-radius:16px;padding:15px 17px;margin-bottom:24px}
-.chips{display:flex;flex-wrap:wrap;gap:7px;margin-bottom:13px}
-.chip{font-size:12px;padding:4px 10px;border-radius:8px;font-weight:600}
-.chip.has{background:var(--bg);color:var(--ink)}
-.chip.miss{border:1.5px dashed var(--muted);color:var(--ink2);padding:2.5px 8.5px}
-.why{font-size:13.5px;color:var(--ink);margin:0;padding-top:13px;border-top:1.5px solid var(--bg);font-weight:600}
-.why span{color:var(--ink2);display:block;margin-top:4px;font-size:12.5px;font-weight:400}
-.bar{display:flex;height:10px;gap:3px;margin-bottom:15px}
-.bar div{border-radius:3px}
-.row{display:flex;align-items:baseline;gap:11px;padding:8px 0;border-bottom:1.5px solid var(--bg)}
-.row:last-child{border-bottom:none}
-.dot{width:9px;height:9px;border-radius:3px;flex:none;position:relative;top:-1px}
-.n{font-variant-numeric:tabular-nums;font-weight:700;min-width:32px;text-align:right;font-size:16px;color:var(--ink)}
-.lb{flex:1;color:var(--ink)}
-.ac{font-size:12.5px;color:var(--ink2);text-align:right}
-.mv{font-size:12.5px;color:var(--ink2);padding:5px 0}
-.mv b{color:var(--ink);font-weight:700}
-.aud{font-size:12.5px;color:var(--ink2);padding:5px 0}
-.aud code{background:var(--bg);padding:2.5px 8px;border-radius:6px;font-size:12px;color:var(--ink);font-weight:600}
-.acts{display:flex;align-items:center;gap:14px;margin-top:26px;flex-wrap:wrap}
-.lg3 button{font-family:inherit;cursor:pointer;font-weight:600;transition:opacity .15s}
-.lg3 button:hover{opacity:.85}
-.go{display:flex;align-items:center;gap:13px;background:none;border:none;padding:0;color:var(--ink);font-size:14px;text-align:left}
-.circ{width:52px;height:52px;border-radius:50%;background:var(--green);color:var(--ink);display:flex;align-items:center;justify-content:center;font-size:17px;flex:none}
-.go small{display:block;font-weight:400;font-size:12.5px;color:var(--ink2)}
-.ghost{background:none;border:1.5px solid var(--muted);color:var(--ink);padding:12px 20px;border-radius:12px;font-size:14px}
-.hint{font-size:12px;color:var(--ink3);margin:13px 0 0}
-</style>
+### The contextual CTA (only when LGM isn't connected)
 
-<div class="lg3">
-  <div class="brick" style="width:150px;height:150px;top:-44px;right:32px;opacity:.9">
-    <svg style="position:absolute;top:0;right:0;width:150px;height:150px" width="173" height="173" viewBox="0 0 173 173" fill="none"><g clip-path="url(#g1)"><g clip-path="url(#g2)"><path transform="rotate(180, 86.5, 86.5)" d="M25.819 78.631C8.442 78.631 -5.639 64.549 -5.639 47.184V7.87C-5.639 3.527 -9.166 0 -13.507 0C-17.847 0 -21.375 3.527 -21.375 7.869V47.184C-21.375 64.563 -35.455 78.631 -52.819 78.631H-92.132C-96.473 78.631 -100 82.16 -100 86.5C-100.001 87.5334 -99.7974 88.5568 -99.4022 89.5117C-99.007 90.4666 -98.4275 91.3342 -97.6967 92.065C-96.966 92.7958 -96.0985 93.3755 -95.1436 93.7708C-94.1888 94.1661 -93.1654 94.3694 -92.132 94.369H-52.819C-35.456 94.369 -21.375 108.451 -21.375 125.816V165.131C-21.375 169.473 -17.848 173 -13.507 173C-9.166 173 -5.639 169.473 -5.639 165.131V125.816C-5.639 108.451 8.442 94.369 25.819 94.369H65.132C69.473 94.369 73 90.841 73 86.5C73 82.159 69.473 78.631 65.132 78.631H25.819Z" fill="#F2F0F5"/></g></g><defs><clipPath id="g1"><rect width="173" height="173" fill="#fff"/></clipPath><clipPath id="g2"><rect width="173" height="173" fill="#fff"/></clipPath></defs></svg>
-  </div>
-
-  <h3>{L_TITLE}</h3>
-  <p class="sub">{AUDIENCE_NAME} · {TOTAL} leads</p>
-
-  <p class="z">1 · {L_COVERAGE}</p>
-  <div class="card">
-    <div class="chips">{COVERAGE_CHIPS}</div>
-    {COVERAGE_NOTE}
-  </div>
-
-  <p class="z">2 · {L_SEGMENTATION}</p>
-  <div class="bar">
-    <div style="width:{PCT_MATCH}%;background:#1E1735"></div>
-    <div style="width:{PCT_REVIEW}%;background:#5A5170"></div>
-    <div style="width:{PCT_NOMATCH}%;background:#8A82A0"></div>
-    <div style="width:{PCT_EXCLUDED}%;background:#fff;border:1.5px solid #8A82A0;box-sizing:border-box"></div>
-  </div>
-  <div class="card" style="padding:7px 17px">
-    <div class="row"><span class="dot" style="background:#1E1735"></span><span class="n">{N_MATCH}</span><span class="lb">{L_MATCH}</span><span class="ac">{L_MATCH_ACTION}</span></div>
-    <div class="row"><span class="dot" style="background:#5A5170"></span><span class="n">{N_REVIEW}</span><span class="lb">{L_REVIEW}</span><span class="ac">{L_REVIEW_ACTION}</span></div>
-    <div class="row"><span class="dot" style="background:#8A82A0"></span><span class="n">{N_NOMATCH}</span><span class="lb">{L_NOMATCH}</span><span class="ac">{L_NOMATCH_ACTION}</span></div>
-    <div class="row"><span class="dot" style="background:#fff;border:1.5px solid #8A82A0"></span><span class="n">{N_EXCLUDED}</span><span class="lb">{L_EXCLUDED}</span><span class="ac">{L_EXCLUDED_ACTION}</span></div>
-  </div>
-
-  <p class="z">3 · {L_PASS2}</p>
-  <div class="card">{PASS2_ROWS}</div>
-
-  <p class="z">4 · {L_AUDIENCES}</p>
-  <div class="card">
-    <div class="aud"><code>[icp] {AUDIENCE_NAME}</code> · {N_MATCH} leads</div>
-    <div class="aud"><code>[review] {AUDIENCE_NAME}</code> · {N_REVIEW} leads</div>
-  </div>
-
-  <div class="acts">{GREEN_BUTTON}{GHOST_BUTTON}</div>
-  <p class="hint">{L_SOURCE_UNTOUCHED}</p>
-</div>
-```
-
-**Filling it**
-
-| Placeholder | Content |
-|---|---|
-| `{COVERAGE_CHIPS}` | one `<span class="chip has">Field NN%</span>` per sufficient field, `<span class="chip miss">Field —</span>` per insufficient one, from `--coverage` |
-| `{COVERAGE_NOTE}` | a `<p class="why">` stating **the consequence first** ("2 ICP criteria are unusable: geography and industry"), then a `<span>` explaining why it matters and that enrichment fills those fields. Omit the whole block when coverage is clean |
-| `{PASS2_ROWS}` | one `<div class="mv"><b>Title</b> · from → to — reason</div>` per reclassification. When nothing moved, a single row saying so |
-| `{GREEN_BUTTON}` | the green circle button — enrichment when criteria are blocked, otherwise create-audiences (see the green rule above) |
-| `{GHOST_BUTTON}` | the other action, as `<button class="ghost">` |
-| `{L_*}` | visible labels, in the user's language |
-
-Green circle button (enrichment variant):
-```html
-<button class="go" onclick="sendPrompt('Run profile enrichment on this audience so I can filter by location and industry')">
-  <span class="circ">▶</span><span>{L_ENRICH}<small>{L_ENRICH_WHY} · {N} credits</small></span>
-</button>
-```
-
-Green circle button (create-audiences variant):
-```html
-<button class="go" onclick="sendPrompt('Create the [icp] and [review] complementary audiences in La Growth Machine')">
-  <span class="circ">▶</span><span>{L_CREATE}<small>{N_MATCH} + {N_REVIEW} leads</small></span>
-</button>
-```
-
-Below the widget, output the match table as native Markdown, then one line on what drove the review bucket.
-
-Then close with exactly **one** contextual CTA. The primary button already carries it when LGM is connected; use the branches below otherwise:
-
-**LGM MCP connected** — the widget's primary button is the CTA. Add one line under it confirming what will happen, and confirm before anything that spends credits or quota.
+When LGM is connected, the green button *is* the CTA — nothing to add beyond the one-line confirmation. Use the branches below only when LGM isn't connected:
 
 **LGM MCP connected but the action isn't exposed** — they already pay, don't push signup:
 > "Quickest path from here: do it manually in [the LGM app](https://app.lagrowthmachine.com/audiences?utm_source=claude_skill&utm_medium=mcp&utm_campaign=audience-icp-filter)."

--- a/skills/fuel-my-pipeline/audience-icp-filter/references/result-widget.html
+++ b/skills/fuel-my-pipeline/audience-icp-filter/references/result-widget.html
@@ -1,0 +1,199 @@
+<!--
+  Audience ICP Filter — the SINGLE result artifact.
+  One visualize:show_widget render. Three fixed zones:
+    1. Data coverage   2. Segmentation   3. Action (state-driven)
+  Zone 3 is the ONLY action area and shows exactly one primary path:
+    - mode "enrich"  → coverage blocked a criterion; green enrichment CTA, nothing else.
+    - mode "review"  → an inline triage deck over the ambiguous residue, THEN the green Create CTA.
+    - mode "create"  → no residue; the green Create CTA directly.
+  There is no separate review-deck widget any more — it lives here.
+
+  Fill the CFG and L objects at the bottom, and the zone 1/2 placeholders.
+  Green (#3DDC84) is reserved for the Create CTA and enrichment CTA only
+  (LGM brand: green = action). Triage buttons are neutral; only their ✓/✕
+  icons carry green / coral, with a NAVY glyph (contrast-checked).
+  Copyable text (the match table) is NOT in here — it goes below as Markdown.
+  {L_*} visible strings follow the user's language; sendPrompt stays English.
+-->
+<h2 class="sr-only">{L_A11Y}</h2>
+<style>
+.u{--bg:#F2F0F5;--ink:#1E1735;--ink2:#5A5170;--ink3:#6E6685;--muted:#8A82A0;--green:#3DDC84;--coral:#F07060;
+background:var(--bg);color:var(--ink);border-radius:24px;padding:26px 28px;margin:.5rem 0;position:relative;overflow:hidden;
+font-family:'PP Telegraf',system-ui,-apple-system,sans-serif;font-size:14px;line-height:1.5}
+.u *{position:relative;z-index:1}
+.u .deco{position:absolute;z-index:0;top:-46px;right:-40px;width:150px;height:150px;border-radius:22px;overflow:hidden;background:#fff;transform:rotate(18deg)}
+.u .deco svg{position:absolute;top:0;left:0;width:150px;height:150px}
+.u h3{font-size:21px;font-weight:700;margin:0 0 2px;letter-spacing:-.01em}
+.u .sub{font-size:13px;color:var(--ink2);margin:0 0 24px}
+.u .z{font-size:10.5px;letter-spacing:.09em;text-transform:uppercase;color:var(--ink3);margin:0 0 10px;font-weight:700}
+.u .card{background:#fff;border-radius:16px;padding:15px 17px;margin-bottom:22px}
+.chips{display:flex;flex-wrap:wrap;gap:7px}
+.chip{font-size:12px;padding:4px 10px;border-radius:8px;font-weight:600;background:var(--bg);color:var(--ink)}
+.chip.miss{border:1.5px dashed var(--muted);color:var(--ink2);background:transparent;padding:2.5px 8.5px}
+.why{font-size:13px;color:var(--ink);margin:10px 0 0;padding-top:11px;border-top:1.5px solid var(--bg);font-weight:600}
+.why span{color:var(--ink2);display:block;margin-top:4px;font-size:12.5px;font-weight:400}
+.bar{display:flex;height:10px;gap:3px;margin-bottom:14px}
+.bar div{border-radius:3px}
+.row{display:flex;align-items:baseline;gap:11px;padding:7px 0;border-bottom:1.5px solid var(--bg)}
+.row:last-child{border-bottom:none}
+.dot{width:9px;height:9px;border-radius:3px;flex:none;position:relative;top:-1px}
+.n{font-variant-numeric:tabular-nums;font-weight:700;min-width:34px;text-align:right;font-size:16px}
+.lb{flex:1}.ac{font-size:12.5px;color:var(--ink2);text-align:right}
+.row.hot .lb{font-weight:700}
+.row.hot .ac{color:var(--ink);font-weight:600;display:inline-flex;align-items:center;gap:5px;justify-content:flex-end}
+.row.hot .ac .down{width:16px;height:16px;border-radius:50%;background:var(--ink);color:#fff;display:inline-flex;align-items:center;justify-content:center;font-size:10px}
+.act-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
+.act-head .z{margin:0}
+.prog{font-size:12px;color:var(--ink2);font-variant-numeric:tabular-nums;font-weight:600}
+.nm{font-size:18px;font-weight:700;margin:0 0 2px}
+.role{font-size:13.5px;margin:0 0 11px}.role b{font-weight:700}
+.meta{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px}
+.tag{font-size:12px;padding:3px 9px;border-radius:7px;background:var(--bg);color:var(--ink2);font-weight:500}
+.bio{background:var(--bg);border-radius:11px;padding:10px 12px;font-size:12.5px;margin-bottom:11px}
+.bio small{display:block;font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink3);font-weight:700;margin-bottom:3px}
+.rwhy{font-size:12.5px;color:var(--ink3);margin:0}.rwhy b{color:var(--ink2);font-weight:700}
+.btns{display:flex;gap:12px;margin-top:16px}
+.u button{font-family:inherit;cursor:pointer;font-weight:700;border:none;transition:opacity .15s,transform .08s}
+.u button:active{transform:scale(.97)}.u button:hover{opacity:.92}
+.tri{flex:1;display:flex;flex-direction:column;align-items:center;gap:6px;border-radius:14px;padding:14px 0 12px;font-size:14px}
+.tri .ic{width:34px;height:34px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;color:var(--ink)}
+.skip{background:#fff;border:1.5px solid var(--muted);color:var(--ink2)}
+.skip .ic{background:var(--coral)}
+.keep{background:var(--ink);border:1.5px solid var(--ink);color:#fff}
+.keep .ic{background:var(--green)}
+.foot{display:flex;align-items:center;justify-content:space-between;margin-top:13px;font-size:12px;color:var(--ink3)}
+.undo{background:none;border:none;color:var(--ink2);cursor:pointer;font-family:inherit;font-size:12px;font-weight:600;text-decoration:underline;padding:0}
+.kbd b{color:var(--ink2)}
+.done-line{font-size:13px;color:var(--ink2);margin:0 0 15px;text-align:center}.done-line b{color:var(--ink);font-weight:700}
+.cta{display:flex;align-items:center;justify-content:center;gap:14px;background:var(--green);color:var(--ink);border-radius:16px;padding:17px 22px;width:100%;box-shadow:0 2px 0 rgba(30,23,53,.12)}
+.cta .circ{width:38px;height:38px;border-radius:50%;background:var(--ink);color:var(--green);display:inline-flex;align-items:center;justify-content:center;font-size:16px;flex:none}
+.cta .lbl{font-size:15px;font-weight:700;line-height:1.3;text-align:left}
+.cta .lbl code{background:rgba(30,23,53,.14);padding:1px 6px;border-radius:5px;font-size:13.5px}
+.cta .lbl small{display:block;font-weight:400;font-size:12.5px;margin-top:3px}
+.sec{display:block;margin:14px auto 0;background:none;border:none;color:var(--ink2);font-size:12.5px;font-weight:600;text-decoration:underline;cursor:pointer}
+.hint{font-size:12px;color:var(--ink3);margin:13px 0 0}
+</style>
+
+<div class="u" id="u">
+  <div class="deco">
+    <svg width="173" height="173" viewBox="0 0 173 173" fill="none"><g clip-path="url(#du1)"><g clip-path="url(#du2)"><path d="M25.819 78.631C8.442 78.631 -5.639 64.549 -5.639 47.184V7.87C-5.639 3.527 -9.166 0 -13.507 0C-17.847 0 -21.375 3.527 -21.375 7.869V47.184C-21.375 64.563 -35.455 78.631 -52.819 78.631H-92.132C-96.473 78.631 -100 82.16 -100 86.5C-100.001 87.5334 -99.7974 88.5568 -99.4022 89.5117C-99.007 90.4666 -98.4275 91.3342 -97.6967 92.065C-96.966 92.7958 -96.0985 93.3755 -95.1436 93.7708C-94.1888 94.1661 -93.1654 94.3694 -92.132 94.369H-52.819C-35.456 94.369 -21.375 108.451 -21.375 125.816V165.131C-21.375 169.473 -17.848 173 -13.507 173C-9.166 173 -5.639 169.473 -5.639 165.131V125.816C-5.639 108.451 8.442 94.369 25.819 94.369H65.132C69.473 94.369 73 90.841 73 86.5C73 82.159 69.473 78.631 65.132 78.631H25.819Z" fill="#F2F0F5"/></g></g><defs><clipPath id="du1"><rect width="173" height="173" fill="#fff"/></clipPath><clipPath id="du2"><rect width="173" height="173" fill="#fff"/></clipPath></defs></svg>
+  </div>
+
+  <h3>{L_TITLE}</h3>
+  <p class="sub">{AUDIENCE_NAME} · {TOTAL} leads</p>
+
+  <p class="z">1 · {L_COVERAGE}</p>
+  <div class="card">
+    <div class="chips">{COVERAGE_CHIPS}</div>
+    {COVERAGE_NOTE}
+  </div>
+
+  <p class="z">2 · {L_SEGMENTATION}</p>
+  <div class="bar">
+    <div style="width:{PCT_MATCH}%;background:#1E1735"></div>
+    <div style="width:{PCT_REVIEW}%;background:#5A5170"></div>
+    <div style="width:{PCT_NOMATCH}%;background:#8A82A0"></div>
+    <div style="width:{PCT_EXCLUDED}%;background:#fff;border:1.5px solid #8A82A0;box-sizing:border-box"></div>
+  </div>
+  <div class="card" style="padding:6px 17px">
+    <div class="row"><span class="dot" style="background:#1E1735"></span><span class="n">{N_MATCH}</span><span class="lb">{L_MATCH}</span><span class="ac">{L_MATCH_ACTION}</span></div>
+    <div class="row hot"><span class="dot" style="background:#5A5170"></span><span class="n">{N_REVIEW}</span><span class="lb">{L_REVIEW}</span><span class="ac"><span class="down">↓</span>{L_BELOW}</span></div>
+    <div class="row"><span class="dot" style="background:#8A82A0"></span><span class="n">{N_NOMATCH}</span><span class="lb">{L_NOMATCH}</span><span class="ac">{L_NOMATCH_ACTION}</span></div>
+    <div class="row"><span class="dot" style="background:#fff;border:1.5px solid #8A82A0"></span><span class="n">{N_EXCLUDED}</span><span class="lb">{L_EXCLUDED}</span><span class="ac">{L_EXCLUDED_ACTION}</span></div>
+  </div>
+
+  <div class="act-head"><p class="z" id="zlabel"></p><span class="prog" id="prog"></span></div>
+  <div class="card" id="stage"></div>
+  <p class="hint">{L_SOURCE_UNTOUCHED}</p>
+</div>
+
+<script>
+(function(){
+  // ---- filled by Claude ----
+  var CFG = {
+    mode: "review",                 // "enrich" | "review" | "create"
+    audience: "{AUDIENCE_NAME}",
+    matchBase: {N_MATCH},           // confident matches that always go to [icp]
+    enrich: { n: 0, why: "" },      // used only when mode === "enrich"
+    leads: {REVIEW_LEADS_JSON}      // [] when none; each: {id,fn,ln,title,co,loc,ind,bio,why}
+  };
+  var L = {
+    reviewHead:"{L_ACT_REVIEW_HEAD}", createHead:"{L_ACT_CREATE_HEAD}", enrichHead:"{L_ACT_ENRICH_HEAD}",
+    skip:"{L_SKIP}", keep:"{L_KEEP}", undo:"{L_UNDO}", kept:"{L_KEPT}", kbd:"{L_KBD}",
+    noTitle:"{L_NO_TITLE}", why:"{L_WHY}", bio:"{L_BIO}",
+    doneKept:"{L_DONE_KEPT}", ofN:"{L_OF_N}", willHold:"{L_WILL_HOLD}",
+    create:"{L_CREATE}", auto:"{L_AUTO}", keptWord:"{L_KEPT_WORD}", sourceKept:"{L_SOURCE_KEPT}",
+    resume:"{L_RESUME}", enrich:"{L_ENRICH}", enrichWhy:"{L_ENRICH_WHY}", credits:"{L_CREDITS}"
+  };
+  // --------------------------------
+
+  var i=0, dec=[], stage=document.getElementById('stage'),
+      prog=document.getElementById('prog'), zlabel=document.getElementById('zlabel');
+  function esc(s){return (s||'').replace(/[&<>"]/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});}
+
+  function enrichView(){
+    zlabel.textContent=L.enrichHead; prog.style.display='none';
+    stage.innerHTML='<button class="cta" onclick="U.enrich()"><span class="circ">▶</span>'
+      +'<span class="lbl">'+esc(L.enrich)+'<small>'+esc(CFG.enrich.why||L.enrichWhy)+' · '+CFG.enrich.n+' '+esc(L.credits)+'</small></span></button>';
+  }
+
+  function card(l){
+    var meta=[];
+    if(l.loc) meta.push('<span class="tag">📍 '+esc(l.loc)+'</span>');
+    if(l.ind) meta.push('<span class="tag">'+esc(l.ind)+'</span>');
+    var role=(l.title?'<b>'+esc(l.title)+'</b>':'<span style="color:var(--ink3)">'+esc(L.noTitle)+'</span>')+(l.co?' · '+esc(l.co):'');
+    return '<p class="nm">'+esc(l.fn)+' '+esc(l.ln)+'</p><p class="role">'+role+'</p>'
+      +(meta.length?'<div class="meta">'+meta.join('')+'</div>':'')
+      +'<div class="bio"><small>'+esc(L.bio)+'</small>'+esc(l.bio||'—')+'</div>'
+      +'<p class="rwhy"><b>'+esc(L.why)+' :</b> '+esc(l.why)+'</p>'
+      +'<div class="btns">'
+      +'<button class="tri skip" onclick="U.d(0)"><span class="ic">✕</span>← '+esc(L.skip)+'</button>'
+      +'<button class="tri keep" onclick="U.d(1)"><span class="ic">✓</span>'+esc(L.keep)+' →</button>'
+      +'</div>'
+      +'<div class="foot"><button class="undo" onclick="U.u()" '+(dec.length?'':'disabled style="opacity:.35"')+'>↩ '+esc(L.undo)+'</button>'
+      +'<span class="kbd">'+esc(L.kept)+' : <b>'+dec.filter(function(d){return d.keep;}).length+'</b></span></div>';
+  }
+
+  function reviewView(){
+    if(i>=CFG.leads.length) return createView();
+    zlabel.textContent=L.reviewHead; prog.style.display=''; prog.textContent=(i+1)+' / '+CFG.leads.length;
+    stage.innerHTML=card(CFG.leads[i]);
+  }
+
+  function createView(){
+    var kept=dec.filter(function(d){return d.keep;}).length, total=CFG.matchBase+kept;
+    zlabel.textContent=L.createHead; prog.style.display='none';
+    var done = CFG.leads.length
+      ? '<p class="done-line">'+esc(L.doneKept)+' <b>'+kept+'</b> '+esc(L.ofN).replace('{n}',CFG.leads.length)+' · '+esc(L.willHold).replace('{m}',CFG.matchBase).replace('{k}',kept)+'</p>'
+      : '';
+    stage.innerHTML=done
+      +'<button class="cta" onclick="U.create('+total+','+kept+')"><span class="circ">▶</span>'
+      +'<span class="lbl">'+esc(L.create)+' <code>[icp] '+esc(CFG.audience)+'</code> · '+total+' leads'
+      +'<small>'+CFG.matchBase+' '+esc(L.auto)+' + '+kept+' '+esc(L.keptWord)+' · '+esc(L.sourceKept)+'</small></span></button>'
+      +(CFG.leads.length?'<button class="sec" onclick="U.restart()">↩ '+esc(L.resume)+'</button>':'');
+  }
+
+  window.U={
+    d:function(keep){ dec.push({id:CFG.leads[i].id,keep:!!keep}); i++; reviewView(); },
+    u:function(){ if(!dec.length)return; dec.pop(); if(i>0)i--; reviewView(); },
+    restart:function(){ i=0; dec=[]; reviewView(); },
+    enrich:function(){ if(window.sendPrompt) sendPrompt('Run profile enrichment on this audience so I can filter by location and industry'); },
+    create:function(total,kept){
+      if(!window.sendPrompt) return;
+      var ids=dec.filter(function(d){return d.keep;}).map(function(d){return d.id;}).join(', ');
+      sendPrompt('Create the [icp] audience in La Growth Machine: the '+CFG.matchBase+' confident matches plus the '+kept+' leads I kept ('+ids+') — '+total+' total. Leave the source audience untouched.');
+    }
+  };
+
+  document.addEventListener('keydown',function(e){
+    if(CFG.mode!=='review' || i>=CFG.leads.length) return;
+    if(e.key==='ArrowRight'){e.preventDefault();U.d(1);}
+    else if(e.key==='ArrowLeft'){e.preventDefault();U.d(0);}
+    else if(e.key==='Backspace'){e.preventDefault();U.u();}
+  });
+
+  if(CFG.mode==='enrich') enrichView();
+  else if(CFG.mode==='review' && CFG.leads.length) reviewView();
+  else createView();
+})();
+</script>

--- a/skills/fuel-my-pipeline/audience-icp-filter/references/title-taxonomy.json
+++ b/skills/fuel-my-pipeline/audience-icp-filter/references/title-taxonomy.json
@@ -102,5 +102,21 @@
   "noise_patterns": [
     "\\bstudent\\b", "\\bintern\\b", "\\bopen to work\\b", "\\bseeking\\b",
     "\\bjob seeker\\b", "\\bretired\\b", "\\bventure scout\\b", "\\bangel investor\\b"
+  ],
+  "_industry_synonyms_comment": "When the user's ICP industries list contains a key (or the key contains it), the variants are added before matching. LinkedIn writes SaaS a dozen ways; this keeps a real SaaS company from being wrongly dropped as no_match. Match is substring, case-insensitive.",
+  "industry_synonyms": {
+    "saas": ["software development", "computer software", "software", "technology, information and internet", "information technology", "it services", "internet", "saas", "b2b software", "enterprise software"],
+    "software": ["software development", "computer software", "software", "technology, information and internet", "information technology", "it services", "internet", "saas"],
+    "tech": ["software development", "computer software", "technology, information and internet", "information technology", "it services", "internet", "information services", "data infrastructure and analytics", "technology"],
+    "fintech": ["financial services", "fintech", "banking", "software development", "technology, information and internet"],
+    "healthtech": ["hospitals and health care", "health, wellness and fitness", "medical devices", "biotechnology research", "software development"],
+    "ecommerce": ["retail", "e-commerce", "consumer goods", "internet", "software development"]
+  },
+  "_agency_comment": "Agency / freelance / consulting signals. NOT an auto-exclude (some agencies are ICP) — a lead whose company or bio hits these is FLAGGED so pass 2 gives it a look instead of trusting the auto-match. Checked against company name and bio.",
+  "agency_patterns": [
+    "\\bagenc(e|y|ies)\\b", "\\bfreelance", "\\bfreelanc", "\\bind[eé]pendant", "\\bfractional\\b",
+    "\\bconsult(ing|ant|ance)\\b", "\\bconseil\\b", "\\bstudio\\b", "\\bcollective\\b", "\\bcollectif\\b",
+    "\\bself-?employed\\b", "\\bauto-?entrepreneur\\b", "\\b\\bEI\\b", "\\bsole trader\\b", "\\bportage\\b",
+    "\\bsolopreneur\\b", "\\bexternalis", "\\boutsourc"
   ]
 }

--- a/skills/fuel-my-pipeline/audience-icp-filter/scripts/build.py
+++ b/skills/fuel-my-pipeline/audience-icp-filter/scripts/build.py
@@ -46,8 +46,42 @@ def _load_taxonomy(path=TAXONOMY_PATH):
         "function": {f["key"]: [re.compile(p, re.I) for p in f["patterns"]]
                      for f in raw["function"]},
         "noise": [re.compile(p, re.I) for p in raw["noise_patterns"]],
+        "industry_synonyms": {k.lower(): [v.lower() for v in vs]
+                              for k, vs in raw.get("industry_synonyms", {}).items()},
+        "agency": [re.compile(p, re.I) for p in raw.get("agency_patterns", [])],
     }
     return tax
+
+
+def expand_industries(industries, tax):
+    """Add known LinkedIn industry variants for any canonical bucket the user
+    named. 'SaaS' alone would miss a company labelled 'Technology, Information
+    and Internet'; expanding it up front stops that lead becoming a false
+    no_match the model then has to repair. Returns a de-duplicated list."""
+    if not industries:
+        return industries
+    syn = tax.get("industry_synonyms", {})
+    out = []
+    for term in industries:
+        t = term.strip().lower()
+        out.append(term)
+        for key, variants in syn.items():
+            if key in t or t in key:
+                out.extend(variants)
+    seen, dedup = set(), []
+    for x in out:
+        xl = x.lower()
+        if xl not in seen:
+            seen.add(xl)
+            dedup.append(x)
+    return dedup
+
+
+def is_agency(lead, tax):
+    """True if the lead's company or bio reads like an agency / freelance /
+    consulting shop. Not an exclusion — a flag so pass 2 double-checks."""
+    hay = (_norm(lead.get("companyName")) + " | " + _norm(lead.get("shortBio")))
+    return any(p.search(hay) for p in tax.get("agency", []))
 
 
 # ---------------------------------------------------------------- validation
@@ -224,11 +258,26 @@ def classify(lead, icp, exclusions, tax):
         if pat.search(tl):
             return "no_match", f"noise title: {title}"
 
+    # The title is the primary signal, but since enrichment now exposes the bio,
+    # use it as a fallback: many people write their function in the bio, not the
+    # title ("Managing Director" + bio "Développement commercial"). Only fall
+    # back when the title is silent — the title is more reliable when present.
+    bio = _norm(lead.get("shortBio")).lower()
+
     seniority = detect_seniority(tl, tax)
+    sen_src = "title"
+    if seniority is None and bio:
+        seniority = detect_seniority(bio, tax)
+        sen_src = "bio"
+
     functions = detect_functions(tl, tax)
+    fn_src = "title"
+    if not functions and bio:
+        functions = detect_functions(bio, tax)
+        fn_src = "bio"
 
     if seniority is None:
-        return "review", f"seniority unclear from title: {title}"
+        return "review", f"seniority unclear from title or bio: {title}"
 
     if seniority not in icp["seniority"]:
         return "no_match", f"seniority {seniority} not in ICP"
@@ -238,7 +287,7 @@ def classify(lead, icp, exclusions, tax):
 
     if not founder_pass:
         if not functions:
-            return "review", f"function unclear from title: {title}"
+            return "review", f"function unclear from title or bio: {title}"
         if not set(functions) & set(icp["functions"]):
             return "no_match", f"function {functions} not in ICP"
 
@@ -252,6 +301,13 @@ def classify(lead, icp, exclusions, tax):
     detail = f"{seniority}"
     if functions:
         detail += f" / {'+'.join(functions)}"
+    src = []
+    if sen_src == "bio":
+        src.append("seniority from bio")
+    if fn_src == "bio":
+        src.append("function from bio")
+    if src:
+        detail += f" (inferred: {', '.join(src)} — worth a pass-2 glance)"
     return "match", f"ICP match: {detail}"
 
 
@@ -259,11 +315,15 @@ def build(spec):
     validate_spec(spec)
     tax = _load_taxonomy()
 
-    icp = spec["icp"]
+    icp = dict(spec["icp"])
+    # expand SaaS/tech/etc. into their real LinkedIn industry variants up front
+    if icp.get("industries"):
+        icp["industries"] = expand_industries(icp["industries"], tax)
     exclusions = spec.get("exclusions", {}) or {}
     leads = spec["leads"]
 
     result = {b: [] for b in BUCKETS}
+    queue = []
     for i, lead in enumerate(leads):
         bucket, reason = classify(lead, icp, exclusions, tax)
         key = _norm(lead.get("leadId")) or \
@@ -272,6 +332,25 @@ def build(spec):
         row["_key"] = key
         row["_bucket"] = bucket
         row["_reason"] = reason
+
+        # Flag the leads pass 2 should actually look at — so it reviews ~a few
+        # dozen, not the whole audience. Three risk classes:
+        flag = None
+        if bucket == "review":
+            flag = "ambiguous"                                   # always
+        elif bucket == "match":
+            if "inferred:" in reason:
+                flag = "bio-inferred match"                      # soft match
+            elif is_agency(lead, tax):
+                flag = "agency/freelance — confirm it's the ICP" # false-positive risk
+        elif bucket == "no_match":
+            # dropped ONLY on a soft substring criterion → likely false negative
+            if reason.startswith("location outside") or reason.startswith("industry outside"):
+                flag = "dropped on geo/industry — check the variant"
+        if flag:
+            row["_flag"] = flag
+            queue.append(row)
+
         result[bucket].append(row)
 
     validate_result(leads, result)
@@ -280,6 +359,8 @@ def build(spec):
         "pass": 1,
         "adjudicated": False,
         "counts": {b: len(result[b]) for b in BUCKETS} | {"total": len(leads)},
+        "pass2_queue_size": len(queue),
+        "pass2_queue": queue,
         "buckets": result,
     }
 
@@ -467,6 +548,12 @@ def _selftest():
          "no_match", "noise title"),
         ({"leadId": "11", "jobTitle": "General Manager of Sales and Marketing",
           "companyName": "20Cube"}, "match", "vp_head + sales/marketing"),
+        ({"leadId": "12", "jobTitle": "Managing Director", "companyName": "Acme",
+          "shortBio": "Développement commercial B2B"},
+         "match", "function comes from bio, not the title"),
+        ({"leadId": "13", "jobTitle": "Principal", "companyName": "Acme",
+          "shortBio": "Woodworking hobbyist and dad of three"},
+         "review", "bio has no function signal either — stays in review"),
     ]
 
     failures = 0
@@ -511,6 +598,45 @@ def _selftest():
        sum(out["counts"][b] for b in BUCKETS) != len(cases):
         failures += 1
         print("FAIL [reconciliation] counts do not add up", file=sys.stderr)
+
+    # --- industry synonym expansion: 'saas' must catch a LinkedIn-labelled variant ---
+    icp_saas = {"seniority": ["founder_c", "vp_head"], "functions": ["growth_marketing"],
+                "founder_qualifies_regardless_of_function": False, "industries": ["saas"]}
+    total += 1
+    got, reason = classify(
+        {"leadId": "s1", "jobTitle": "Head of Marketing", "companyName": "Implicity",
+         "industry": "Technology, Information and Internet"},
+        {**icp_saas, "industries": expand_industries(icp_saas["industries"], tax)}, {}, tax)
+    if got != "match":
+        failures += 1
+        print(f"FAIL [industry synonym] expected match got {got} ({reason})", file=sys.stderr)
+
+    # a genuinely off-industry lead still drops
+    total += 1
+    got, _ = classify(
+        {"leadId": "s2", "jobTitle": "Head of Marketing", "companyName": "TotalEnergies",
+         "industry": "Oil and Gas"},
+        {**icp_saas, "industries": expand_industries(icp_saas["industries"], tax)}, {}, tax)
+    if got != "no_match":
+        failures += 1
+        print(f"FAIL [off-industry] expected no_match got {got}", file=sys.stderr)
+
+    # --- pass2_queue is bounded: only ambiguous / risky / soft-drops, not everything ---
+    total += 1
+    qout = build({"icp": {**icp_saas, "industries": ["saas"]}, "exclusions": {}, "leads": [
+        {"leadId": "q1", "jobTitle": "Head of Marketing", "companyName": "Acme",
+         "industry": "Software Development"},                       # clean match, NOT queued
+        {"leadId": "q2", "jobTitle": "Head of Marketing", "companyName": "Freelance Studio",
+         "industry": "Software Development", "shortBio": "Freelance CMO / consultant"},  # agency match → queued
+        {"leadId": "q3", "jobTitle": "Head of Marketing", "companyName": "EnergyCo",
+         "industry": "Renewables & Environment"},                   # dropped on industry → queued
+        {"leadId": "q4", "jobTitle": "Software Engineer", "companyName": "Acme",
+         "industry": "Software Development"},                       # dropped on FUNCTION → NOT queued
+    ]})
+    qkeys = {r["_key"] for r in qout["pass2_queue"]}
+    if qkeys != {"q2", "q3"} or qout["pass2_queue_size"] != 2:
+        failures += 1
+        print(f"FAIL [pass2_queue] expected {{q2,q3}} got {qkeys}", file=sys.stderr)
 
     # --- pass 2: the semantic failures regex cannot see ---
     # 'Chief Happiness Officer' matches the C-level pattern but is an HR role.


### PR DESCRIPTION
## Ce que cette PR change

Refinements majeurs sur `audience-icp-filter` basés sur les runs réels — pas de refonte, on garde la 2-pass architecture, mais on la rend rapide et opérationnelle.

### 1. Pass 2 bornée via `pass2_queue`

**Le vrai bottleneck mesuré : re-lire les 250 leads en pass 2 prenait 8 minutes.** Pass 1 renvoie maintenant `pass2_queue` — un set ciblé de leads suspects, chacun taggé d'un `_flag` :

| `_flag` | Ce que c'est |
|---|---|
| `ambiguous` | tout le bucket `review` |
| `bio-inferred match` | matché via la bio, pas le titre — confirmer |
| `agency/freelance — confirm it's the ICP` | company/bio qui sonne agence/freelance/consultant |
| `dropped on geo/industry — check the variant` | seniority + function OK mais échec sur substring de location/industrie |

Pass 2 review **uniquement cette queue** (typiquement 15-25 leads sur une audience clean), plus les 250 leads. Fixe les 2 vrais failure modes des runs réels : agencies dans `match`, et SaaS classées "Technology, Information and Internet" tombant dans `no_match`.

### 2. Execution style — fast and quiet

Nouvelle section explicite dans SKILL.md :
- **Pass 2 est le job de Claude, pas de l'user.** Une review bucket de 50 leads balancée à l'user = fail. C'est à Claude de descendre la queue et de ne laisser à l'user que la poignée genuinement ambiguë.
- Les fetch de leads (`get_audience_leads`) sont **parallélisés** en batch — plus séquentiels.
- Le reasoning se fait **silencieusement**, pas en narration step-by-step à l'user.

### 3. Widget extrait dans `references/result-widget.html`

199 lignes de HTML sortent de SKILL.md et vont dans leur propre fichier. SKILL.md redevient focus doctrine, référence le widget par path.

### 4. Spec format explicite + 2 règles de calibration

- **`locations` matche sur substring**, donc l'user doit lister les variantes réelles (`"Greater Paris Metropolitan Region"` ne contient pas `"France"`).
- **`industries` auto-expand depuis des buckets connus** (`"saas"` → les labels LinkedIn équivalents). Le `--adjudicate` catch le reste via le flag `dropped on geo/industry`.

### 5. Script et taxonomy grossissent en conséquence

- `scripts/build.py` : 627 → 753 lignes (les flags de queue, le bio-fallback, les synonymes industry)
- `references/title-taxonomy.json` : 106 → 122 lignes
- `references/result-widget.html` : nouveau fichier

## Tests

```
$ python3 scripts/build.py --test
35/35 passed
```

5 nouveaux golden cases par rapport à v1 (30/30), couvrant les real-run failures : agencies en `match`, SaaS variants en `no_match`, geo variants.

## Ce qui n'est PAS touché

`README.md` — le user ne l'a pas mis à jour dans le source, on garde tel quel. Aucun autre skill, aucun autre fichier repo affecté.