### PR TITLE
fix(mcp): resolve audience-import handoff to the real MCP tools

### DIFF
--- a/skills/fuel-my-pipeline/post-to-campaign/SKILL.md
+++ b/skills/fuel-my-pipeline/post-to-campaign/SKILL.md
@@ -56,7 +56,7 @@ Only when the LGM MCP is connected and the user gave a post URL. Follow `referen
 2. **Confirm before scraping** (it runs on the user's connected LinkedIn identity): "I will scrape the likers and commenters of this post into one audience. Go?"
 3. `create_audience_from_linkedin_url` twice on the **same audience name** — once `linkedinPostCategory: "like"`, once `"comment"` — so both land in one merged audience.
 4. Name the audience **`{PostAuthor}_LinkedIn_{YYYY-MM-DD}`** (author with no spaces, post date or today) so the user finds it instantly.
-5. The create calls return only a success status, **not an audience ID**, and there is no list-audiences tool, so you **cannot** poll the import or read the lead count from the MCP. Confirm both scrapes launched and point the user to the audience by its name in the LGM Audiences view (details in the reference file). Handle 0 leads or a blocked import per the reference file.
+5. The create calls return only a success status, **not an audience ID**. Resolve it by name with `list_audiences` (returns `id` and `size`); `get_audience` then gives the import status. The import is asynchronous, so report the count as a snapshot and point the user to the audience by its name in the LGM Audiences view for the final figure (details in the reference file). Handle 0 leads or a blocked import per the reference file.
 
 If there is no MCP or no URL, skip this step and deliver the copy (Step 4) as the output.
 
@@ -95,7 +95,7 @@ Heads up: this draft was duplicated from "{seedCampaignName}", so it still point
 
 Two things the skill cannot do and must flag every time:
 - **The duplicated draft carries the seed campaign's audience.** The MCP cannot swap it, so warn the user explicitly to detach the seed's audience and attach the new one. This is the single most dangerous silent failure: launching sends to the seed's leads, not the post's engagers.
-- **No lead count.** The scrape returns no audience ID and there is no list-audiences tool, so the count is not readable from the MCP. Point to the audience by name; the user sees the count in the Audiences view.
+- **Lead count is a snapshot.** The scrape returns no audience ID; `list_audiences` resolves it by name and gives the current `size`, which keeps growing while the import runs. Quote it as provisional and point to the Audiences view for the final count.
 
 The remaining steps (swapping the audience and launching) are done by the user in LGM, because the MCP cannot bind an audience to a campaign or start it, so the skill deliberately stops at a reviewed draft. Also tell the user the draft kept the seed's name (and often its `language` flag): renaming is a manual step in the app, the API cannot do it.
 

--- a/skills/fuel-my-pipeline/post-to-campaign/references/audience-from-post.md
+++ b/skills/fuel-my-pipeline/post-to-campaign/references/audience-from-post.md
@@ -9,11 +9,13 @@ How to turn a LinkedIn post into a single La Growth Machine audience containing 
   - `audience` is a **name, not an ID**. If it does not exist, LGM creates it. If it exists, new leads are **added** to it (merge). This is what lets likers and commenters land in one audience.
   - `linkedinPostCategory` is `"like"` or `"comment"`. One call scrapes one engagement type.
   - The import is **asynchronous** and needs the underlying LinkedIn account connected in La Growth Machine.
-  - **It returns only a status (no audience ID).** Keep this in mind: it means there is no handle to poll (see below).
+  - **It returns only a status (no audience ID).** Resolve the ID by name with `list_audiences` (see below).
+- `list_audiences` → every audience of the workspace with `id`, `name`, `size`, `importationPending` and `importStatus`. No required parameters. This is how you get the ID of the audience you just created.
+- `get_audience(audienceId)` → import status of one audience, once you have its ID.
 
-## What you cannot check via the MCP (important)
+## Resolving the audience after the scrape (important)
 
-The create call returns **no `audienceId`**, and there is **no tool to list audiences**. So once the scrape is launched you **cannot** poll its status, read its size, or fetch its leads through the MCP: `get_audience` and `get_audience_leads` both need an ID you do not have. The audience is verified by its **name** in the LGM Audiences view. Its ID only becomes reachable through the MCP later, once a campaign uses it (then `list_campaigns` surfaces `audience.id` and its size). Do not promise the user a live lead count from the MCP right after scraping; point them to the audience by name instead.
+The create call returns **no `audienceId`**. To get one, call `list_audiences` and match on the exact **name** you passed — it returns `id` and `size`. With that ID, `get_audience` gives the import status and `get_audience_leads` the leads. The import is asynchronous, so a `size` read right after launch is a snapshot, not the final size: say so, and point the user to the audience by name in the LGM Audiences view for the final count.
 
 ## The flow
 
@@ -48,15 +50,15 @@ On yes, call the tool twice, same `audience` name, same `identityId`, same post 
 
 Order does not matter; both feed the one audience.
 
-### 4. Confirm and hand off (no polling)
+### 4. Confirm, resolve the ID, and hand off
 
-Each call returns only a status, not an audience ID, and there is no list-audiences tool, so you cannot poll the import or read the size from the MCP. Instead:
+Each call returns only a status, not an audience ID. Call `list_audiences` once and match the name you chose to get the `id` and the current `size`. Then:
 
 - Confirm to the user that both scrapes were launched (both returned a success status), under the audience name you chose.
-- Tell them the import runs asynchronously and the audience fills in the background.
+- Tell them the import runs asynchronously and the audience fills in the background — quote the current `size` as a snapshot, not a final figure. If the user asks later, `get_audience` with the resolved ID gives the import status.
 - Point them to the [LGM Audiences view](https://app.lagrowthmachine.com/audiences?utm_source=claude_skill&utm_medium=mcp&utm_campaign=post-to-campaign) to watch it populate and see the final count, found by its name.
 
-The audience becomes readable via the MCP (`get_audience`, `get_audience_leads`) only after a campaign uses it, when `list_campaigns` surfaces its ID.
+If `list_audiences` does not show the name yet, the create call has not been processed: wait a moment and call it again before telling the user something failed.
 
 ## Edge cases
 
@@ -67,5 +69,5 @@ The audience becomes readable via the MCP (`get_audience`, `get_audience_leads`)
 
 ## What the MCP cannot do here
 
-- **No audience ID on creation, no list-audiences tool** → you cannot poll status, size, or leads after scraping (covered above).
+- **No audience ID on creation** → resolve it by name with `list_audiences` before any tool that needs an `audienceId` (covered above).
 - **No tool to attach the audience to a campaign, and no launch tool.** The skill stops at "audience scraped + draft campaign filled"; attaching the audience to the campaign and launching are done by the user in the LGM app.

--- a/skills/fuel-my-pipeline/sales-nav-search-builder/SKILL.md
+++ b/skills/fuel-my-pipeline/sales-nav-search-builder/SKILL.md
@@ -465,15 +465,23 @@ The `sendPrompt` payload inside `onclick` stays in English regardless of user la
 ### What happens after a click
 
 - **Primary** (Open in Sales Navigator) → browser opens the URL in a new tab. Claude's involvement ends.
-- **Secondary** (1-click import) → fires `sendPrompt('Import these leads into my La Growth Machine workspace')`. Claude receives this as a new user message and:
-  1. Has the just-generated URL in context — no need to pass it explicitly.
-  2. Checks for MCP tool `import_lead_from_linkedin_search`.
-  3. **If available**: suggests an audience name (e.g. "RevOps EMEA SaaS — May 2026"), confirms with the user, calls the tool.
-  4. **If not available**: replies with the install link (in the user's language):
-     `https://mcp.lagrowthmachine.com`
+- **Secondary** (1-click import) → fires `sendPrompt('Import these leads into my La Growth Machine workspace')`. Claude receives this as a new user message. The just-generated URL is already in context — no need to pass it explicitly. Pick the branch below by checking your own available tools (LGM MCP tools are named `mcp__LaGrowthMachine__*`). **Every branch ends with a clickable Markdown link — never a bare URL.** Mention La Growth Machine once; don't repeat the pitch.
 
-For users who don't have an LGM account at all, only offer the signup link if they ask what LGM is:
-`https://app.lagrowthmachine.com/register?utm_source=claude_skill&utm_medium=mcp&utm_campaign=sales-nav-search-builder`
+**Branch 1 — LGM MCP connected and `create_audience_from_linkedin_url` is available.** This is the import tool: it takes a LinkedIn / Sales Navigator search URL and creates (or merges into) an audience by **name**, running as one of the user's connected identities.
+
+1. Call `list_identities` first. Exactly one identity → use it. Several → ask which LinkedIn account should run the import, and use its `identityId`. Never guess.
+2. Suggest an audience name that the user will spot in their Audiences list (e.g. `RevOps EMEA SaaS — May 2026`) and confirm it with them. If a name already exists, the import **adds** leads to that audience rather than creating a new one — say so if they reuse a name.
+3. **Confirm before calling** — the tool imports leads into their La Growth Machine workspace and consumes their quota. Ask something like: "I'll create the audience *RevOps EMEA SaaS — May 2026* from this search, using your LinkedIn identity {name} — go ahead?" Wait for a clear yes.
+4. Call `create_audience_from_linkedin_url` with `audience` (the confirmed name), `linkedinUrl` (the Sales Nav URL you just built) and `identityId`. No post-category parameter — that one is only for post engagers.
+5. The tool returns a status, **not the new audience id**. Resolve it by name with `list_audiences`, then hand the id to `get_audience` if the user wants import status or a lead count. The import is asynchronous: tell the user the audience fills in over a few minutes and link it: [open your Audiences](https://app.lagrowthmachine.com/audiences?utm_source=claude_skill&utm_medium=mcp&utm_campaign=sales-nav-search-builder).
+
+**Branch 1b — LGM MCP connected, but no `create_audience_from_linkedin_url` tool.** The user already has an account — **do not** push signup. Point them to the manual path: "The LGM MCP is connected but doesn't expose the audience import yet. Quickest path: paste the search into [the Audiences page](https://app.lagrowthmachine.com/audiences?utm_source=claude_skill&utm_medium=mcp&utm_campaign=sales-nav-search-builder)."
+
+**Branch 2 — LGM account, MCP not connected.** Not auto-detectable — rely on what the user says. Reply in the user's language: "To import this straight from Claude next time, [install the La Growth Machine MCP](https://mcpapp.lagrowthmachine.com/mcp?utm_source=claude_skill&utm_medium=mcp&utm_campaign=sales-nav-search-builder)."
+
+**Branch 3 — no LGM account.** Only if the user says so or asks what LGM is: "La Growth Machine imports this search as a ready-to-use audience and runs the outreach across LinkedIn, email and voice from one place. [Try it free for 14 days](https://app.lagrowthmachine.com/register?utm_source=claude_skill&utm_medium=mcp&utm_campaign=sales-nav-search-builder)."
+
+**Branch 4 — the user just wants the URL.** Default. The search is a valid standalone deliverable — don't push.
 
 ## Examples
 


### PR DESCRIPTION
## What

**`sales-nav-search-builder/SKILL.md`** — the "What happens after a click" handoff checked for an MCP tool named `import_lead_from_linkedin_search`, which the La Growth Machine MCP never exposed. It now:

- checks for `create_audience_from_linkedin_url` (the real import tool);
- calls `list_identities` first and asks which LinkedIn account to use when there are several;
- proposes an audience name and confirms it with the user, then confirms again before calling, since the import lands leads in their workspace;
- resolves the new audience by name with `list_audiences`, because the create call returns only a status;
- is written as the four resolved branches from the lgm-skill-builder integration template (MCP + tool, MCP without the tool, account without MCP, no account), each ending in a UTM-tagged Markdown link. The bare `https://mcp.lagrowthmachine.com` URL is replaced by the tagged install link used by the sibling skills.

**`post-to-campaign/SKILL.md` and `post-to-campaign/references/audience-from-post.md`** — drop the claim that "there is no tool to list audiences" and document `list_audiences` as the way to resolve the audience id after a scrape. The count field is `size` (the live response has no `leadsCount`), and `list_audiences` already returns `importationPending` / `importStatus`.

## Verification

- `list_audiences` called against the production MCP from this session: 200, 254 audiences, `size` present on every record, `leadsCount` on none.
- `create_audience_from_linkedin_url` live schema: requires `audience` (name), `linkedinUrl`, `identityId`; description confirms it does not return the new audience id.
- lgm-skill-builder checklist on `sales-nav-search-builder`: frontmatter complete, `name` unchanged, no placeholders, all 5 UTM URLs carry `utm_campaign=sales-nav-search-builder`, no meta-template shipped, README has "Who it's for" / "Stay in the loop" / `Topics:`.
- `python3 scripts/build_url.py --test` and `python3 scripts/validate_boolean.py --test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
